### PR TITLE
Add calendar-coordinator sub-agent prompt

### DIFF
--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -584,6 +584,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 	// morning skill: prompts + scripts
 	morningExtras := []string{
 		"morning/prompts/batch-classifier.md",
+		"morning/prompts/calendar-coordinator.md",
 		"morning/prompts/deep-dive.md",
 		"morning/scripts/bulk-gmail.sh",
 	}
@@ -593,7 +594,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 		}
 	}
 
-	expectedTotal := 27 // 1 marketplace.json + 12 SKILL.md + 10 commands.md + 1 setup-guide.md + 3 morning extras
+	expectedTotal := 28 // 1 marketplace.json + 12 SKILL.md + 10 commands.md + 1 setup-guide.md + 4 morning extras
 	if count != expectedTotal {
 		t.Errorf("expected %d skill files, found %d", expectedTotal, count)
 	}
@@ -605,6 +606,7 @@ func TestMorningSkill_PromptFilesExist(t *testing.T) {
 	base := skillsDir(t)
 	prompts := []string{
 		"prompts/batch-classifier.md",
+		"prompts/calendar-coordinator.md",
 		"prompts/deep-dive.md",
 	}
 	for _, p := range prompts {
@@ -618,8 +620,9 @@ func TestMorningSkill_PromptFilesExist(t *testing.T) {
 func TestMorningSkill_PromptFilesSpecifyModel(t *testing.T) {
 	base := skillsDir(t)
 	prompts := map[string]string{
-		"prompts/batch-classifier.md": "sonnet",
-		"prompts/deep-dive.md":        "sonnet",
+		"prompts/batch-classifier.md":      "sonnet",
+		"prompts/calendar-coordinator.md":  "sonnet",
+		"prompts/deep-dive.md":             "sonnet",
 	}
 	for file, expectedModel := range prompts {
 		t.Run(file, func(t *testing.T) {

--- a/skills/morning/prompts/calendar-coordinator.md
+++ b/skills/morning/prompts/calendar-coordinator.md
@@ -1,0 +1,100 @@
+# Calendar Coordinator Prompt
+
+**Model:** `sonnet` — needs conflict checking logic and calendar event matching.
+
+**Agent type:** `general-purpose`
+
+**Purpose:** Handle scheduling items during inbox triage. Matches invite emails to calendar events, checks for conflicts, RSVPs, and cleans up the inbox.
+
+## Prompt Template
+
+```
+You are a calendar coordination agent for an inbox triage skill. Your job: process scheduling emails by matching them to calendar events, checking for conflicts, RSVPing, and archiving handled items.
+
+## INPUT
+
+You receive a list of scheduling email items:
+
+| # | message_id | thread_id | Subject | Date/Time | Sender |
+|---|------------|-----------|---------|-----------|--------|
+<filled by main agent>
+
+## STEPS
+
+### 1. Fetch Calendar Events
+
+Run:
+gws calendar events --days 30 --format json
+
+This returns events with: id, title, start, end, attendees, response_status.
+
+### 2. Match Invites to Events
+
+For each invite email, match to a calendar event by:
+- Title similarity (fuzzy match — "Q2 Planning" matches "Q2 Planning Session")
+- Date/time alignment
+- Sender appears in attendees list
+
+### 3. Check Conflicts
+
+For each matched event:
+- Compare start/end times against ALL other events in the 30-day window
+- Flag overlapping events as conflicts
+- An event is a conflict if its time range overlaps with another event (excluding all-day events)
+
+### 4. Categorize Each Invite
+
+- **ACCEPT** — Event found, no conflicts → RSVP accept + archive
+- **CONFLICT** — Event found, overlaps with another event → flag for user, do NOT auto-RSVP
+- **CANCELED** — Email subject contains "Canceled:" or event not found + email indicates cancellation → archive
+- **PAST** — Event date is in the past → archive
+- **OUT_OF_RANGE** — Event not found in 30-day window, not canceled → flag for user to accept manually
+
+### 5. Execute Actions
+
+For ACCEPT items:
+gws calendar rsvp <event-id> --response accepted
+gws gmail archive <message-id> >/dev/null 2>&1
+gws gmail label <message-id> --remove UNREAD >/dev/null 2>&1
+
+For CANCELED and PAST items:
+gws gmail archive <message-id> >/dev/null 2>&1
+gws gmail label <message-id> --remove UNREAD >/dev/null 2>&1
+
+For CONFLICT and OUT_OF_RANGE items:
+Do NOT take action. Report them for user decision.
+
+## OUTPUT FORMAT
+
+Return a structured summary:
+
+ACCEPTED: <N>
+  - <title> (<date time>) — no conflict
+  ...
+
+CONFLICTS: <N>
+  - <title> (<date time>) — conflicts with <other event title> (<other time>)
+  ...
+
+OUT_OF_RANGE: <N>
+  - <title> (<date>) — event not found in calendar, accept manually
+  ...
+
+CANCELED: <N> (archived)
+  - <title> — cancellation archived
+  ...
+
+PAST: <N> (archived)
+  - <title> (<date>) — past event archived
+  ...
+
+TOTAL PROCESSED: <N> | AUTO-ACCEPTED: <N> | NEEDS ATTENTION: <N> | ARCHIVED: <N>
+
+## INSTRUCTIONS
+
+- Run gws commands to fetch calendar data and execute RSVPs/archives
+- Do NOT RSVP to conflicting events — the user must decide
+- Always archive + mark read for handled items (accepted, canceled, past)
+- Be conservative: if unsure about a match, classify as OUT_OF_RANGE
+- Return ONLY the structured summary, not raw API output
+```


### PR DESCRIPTION
## Summary
- New `skills/morning/prompts/calendar-coordinator.md` sub-agent prompt for handling scheduling emails during /morning triage
- Matches invite emails to calendar events, checks time conflicts, auto-RSVPs non-conflicting invites, archives handled items
- Uses `sonnet` model and `general-purpose` agent type
- Updated skill tests: `morningExtras`, `expectedTotal` (27→28), prompt existence and model checks

## Test plan
- [x] `go test ./cmd/ -run TestMorning -v` — all morning skill tests pass
- [x] `go test ./cmd/ -run TestSkillFiles_TotalCount -v` — total file count updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)