### PR TITLE
Add label-resolver sub-agent prompt

### DIFF
--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -586,6 +586,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 		"morning/prompts/batch-classifier.md",
 		"morning/prompts/calendar-coordinator.md",
 		"morning/prompts/deep-dive.md",
+		"morning/prompts/label-resolver.md",
 		"morning/scripts/bulk-gmail.sh",
 	}
 	for _, f := range morningExtras {
@@ -594,7 +595,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 		}
 	}
 
-	expectedTotal := 28 // 1 marketplace.json + 12 SKILL.md + 10 commands.md + 1 setup-guide.md + 4 morning extras
+	expectedTotal := 29 // 1 marketplace.json + 12 SKILL.md + 10 commands.md + 1 setup-guide.md + 5 morning extras
 	if count != expectedTotal {
 		t.Errorf("expected %d skill files, found %d", expectedTotal, count)
 	}
@@ -608,6 +609,7 @@ func TestMorningSkill_PromptFilesExist(t *testing.T) {
 		"prompts/batch-classifier.md",
 		"prompts/calendar-coordinator.md",
 		"prompts/deep-dive.md",
+		"prompts/label-resolver.md",
 	}
 	for _, p := range prompts {
 		path := filepath.Join(base, "morning", p)
@@ -623,6 +625,7 @@ func TestMorningSkill_PromptFilesSpecifyModel(t *testing.T) {
 		"prompts/batch-classifier.md":      "sonnet",
 		"prompts/calendar-coordinator.md":  "sonnet",
 		"prompts/deep-dive.md":             "sonnet",
+		"prompts/label-resolver.md":        "haiku",
 	}
 	for file, expectedModel := range prompts {
 		t.Run(file, func(t *testing.T) {

--- a/skills/morning/prompts/label-resolver.md
+++ b/skills/morning/prompts/label-resolver.md
@@ -1,0 +1,69 @@
+# Label Resolver Prompt
+
+**Model:** `haiku` — simple lookup task, no complex reasoning needed.
+
+**Agent type:** `general-purpose`
+
+**Purpose:** Apply Gmail labels during triage without loading the full label list (4000+ labels) into the main conversation context. Handles fuzzy label matching, archiving, and marking as read.
+
+## Prompt Template
+
+```
+You are a Gmail label resolver agent. Your job: find the best matching label for a requested label name and apply it to a message.
+
+## INPUT
+
+- message_id: <message_id>
+- desired_label: <label name — may be fuzzy, partial, or case-insensitive>
+- action: <"archive" | "mark-read" | "none">
+
+## STEPS
+
+### 1. Fetch Labels
+
+Run:
+gws gmail labels --format json
+
+This returns all Gmail labels with id, name, and type.
+
+### 2. Find Best Match
+
+Match the desired label name against the label list:
+- Exact match (case-insensitive): "ActionNeeded" matches "actionneeded"
+- Partial match: "action" matches "ActionNeeded" if it's the only partial match
+- If multiple partial matches, pick the most specific one
+- If no match found, report the error — do NOT create a label
+
+### 3. Apply Label
+
+Run:
+gws gmail label <message_id> --add "<matched_label_name>"
+
+### 4. Additional Actions
+
+If action is "archive":
+gws gmail archive <message_id> >/dev/null 2>&1
+
+If action is "archive" or "mark-read":
+gws gmail label <message_id> --remove UNREAD >/dev/null 2>&1
+
+## OUTPUT FORMAT
+
+Return a JSON-like summary:
+
+label_applied: "<matched label name>"
+label_id: "<label ID>"
+archived: <true/false>
+marked_read: <true/false>
+
+If no match found:
+error: "No label matching '<desired_label>' found"
+suggestions: ["<closest match 1>", "<closest match 2>"]
+
+## INSTRUCTIONS
+
+- Run gws commands to fetch labels and apply them
+- Be conservative with fuzzy matching — prefer exact matches
+- Do NOT create new labels, only apply existing ones
+- Return ONLY the structured summary
+```


### PR DESCRIPTION
## Summary
- New `skills/morning/prompts/label-resolver.md` — lightweight haiku sub-agent for Gmail label operations during /morning triage
- Handles fuzzy label matching, label application, archive, and mark-read
- Keeps the 4000+ label list out of the main conversation context
- Updated skill tests: `morningExtras`, `expectedTotal` (28→29), prompt existence and model checks (`haiku`)

## Test plan
- [x] `go test ./cmd/ -run TestMorning -v` — all morning skill tests pass
- [x] `go test ./cmd/ -run TestSkillFiles_TotalCount -v` — total file count updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)