### PR TITLE
Track compact-prompt.md for morning session resumption

### DIFF
--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -583,6 +583,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 
 	// morning skill: prompts + scripts
 	morningExtras := []string{
+		"morning/compact-prompt.md",
 		"morning/prompts/batch-classifier.md",
 		"morning/prompts/calendar-coordinator.md",
 		"morning/prompts/deep-dive.md",
@@ -595,7 +596,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 		}
 	}
 
-	expectedTotal := 29 // 1 marketplace.json + 12 SKILL.md + 10 commands.md + 1 setup-guide.md + 5 morning extras
+	expectedTotal := 30 // 1 marketplace.json + 12 SKILL.md + 10 commands.md + 1 setup-guide.md + 6 morning extras
 	if count != expectedTotal {
 		t.Errorf("expected %d skill files, found %d", expectedTotal, count)
 	}

--- a/skills/morning/compact-prompt.md
+++ b/skills/morning/compact-prompt.md
@@ -1,0 +1,82 @@
+# /morning Compact Prompt
+
+Use this when context runs out during a `/morning` triage session. Copy the template below, fill in the state from the conversation, and paste it to resume.
+
+---
+
+## Template
+
+```
+Resume a /morning inbox triage session. Run /gws:morning to load the skill, then continue from the saved state below.
+
+## Config
+
+~/.config/gws/inbox-skill.yaml is already configured. Key settings:
+- OKR sheet: <sheet_id> — <sheet_names>
+- VIP senders: <list>
+- Noise strategy: promotions
+
+## Batch Classification Results
+
+The batch classifier already ran. Here are the results (do NOT re-fetch or re-classify):
+
+### ACT NOW (<N> items)
+| # | ID | From | Subject | Priority | OKR/Task Match | Status |
+|---|-----|------|---------|----------|----------------|--------|
+| 1 | <message_id> | <sender> | <subject> | <1-5> | <match or —> | <DONE: action taken / PENDING> |
+...
+
+### REVIEW (<N> items)
+| # | ID | From | Subject | Priority | OKR/Task Match | Status |
+|---|-----|------|---------|----------|----------------|--------|
+...
+
+### SCHEDULING (<N> items)
+| # | ID | From | Subject | Status |
+|---|-----|------|---------|--------|
+...
+
+### PERIPHERAL (<N> items)
+| # | ID | From | Subject | Status |
+|---|-----|------|---------|--------|
+...
+
+### NOISE (<N> items)
+<N> promotions, <N> non-promo noise. IDs: <comma-separated message_ids>
+Status: <NOT HANDLED / Archived all / Partially handled>
+
+## Actions Taken So Far
+
+| Email | Action | Marked Read |
+|-------|--------|-------------|
+| <sender — subject> | <archived / starred / task created / opened / deleted> | Yes/No |
+...
+
+Tasks created:
+- "<task title>" in <list name>
+...
+
+## Resume Point
+
+Continue from: **<CATEGORY> item [<N>/<TOTAL>]** — <sender — subject>
+<If mid-category, note what was the last item shown and user's last response>
+
+## Corrections Applied
+
+<List any classification corrections the user made during triage, e.g.:>
+- <none, or: "Bar Agam was REVIEW not ACT NOW — she's CC'd, privacy team owns it">
+
+## Notes
+
+<Any other context: user preferences, side tasks started, meetings coming up, etc.>
+```
+
+---
+
+## How to Fill This In
+
+1. **Batch classification**: Copy the structured output from the batch classifier sub-agent. Mark each item as DONE (with action) or PENDING.
+2. **Actions taken**: List every email you acted on — archive, star, task, open, delete. Note if marked read.
+3. **Resume point**: Identify exactly where triage stopped — category, item number, and whether the user was mid-decision.
+4. **Corrections**: Any time the user corrected a classification (e.g., "that's not ACT NOW, I'm CC'd"), note it so the resumed session doesn't repeat the mistake.
+5. **Notes**: Meeting prep started, docs opened, side conversations — anything the user might want to pick back up.


### PR DESCRIPTION
## Summary
- Track existing `skills/morning/compact-prompt.md` file in version control
- Template for resuming /morning triage sessions when context runs out
- Updated skill tests: `morningExtras`, `expectedTotal` (29→30)

## Test plan
- [x] `go test ./cmd/ -run TestMorning -v` — all morning skill tests pass
- [x] `go test ./cmd/ -run TestSkillFiles_TotalCount -v` — total file count updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)