### PR TITLE
Add gmail archive-thread command

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -90,6 +90,7 @@ func TestGmailCommands(t *testing.T) {
 		{"label", "label <message-id>", true},
 		{"archive", "archive <message-id>", true},
 		{"trash", "trash <message-id>", true},
+		{"archive-thread", "archive-thread <thread-id>", true},
 		{"thread", "thread <thread-id>", true},
 	}
 

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -345,7 +345,7 @@ func TestSkillCommands_MatchCLI(t *testing.T) {
 	services := map[string]serviceCommands{
 		"gmail": {
 			parentCmd:   gmailCmd,
-			subcommands: []string{"list", "read", "send", "labels", "label", "archive", "trash", "thread"},
+			subcommands: []string{"list", "read", "send", "labels", "label", "archive", "archive-thread", "trash", "thread"},
 		},
 		"calendar": {
 			parentCmd:   calendarCmd,

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -42,6 +42,7 @@ For initial setup, see the `gws-auth` skill.
 | Add labels | `gws gmail label <message-id> --add "STARRED"` |
 | Remove labels | `gws gmail label <message-id> --remove "UNREAD"` |
 | Archive a message | `gws gmail archive <message-id>` |
+| Archive a thread | `gws gmail archive-thread <thread-id>` |
 | Trash a message | `gws gmail trash <message-id>` |
 
 ## Detailed Usage
@@ -139,6 +140,14 @@ gws gmail archive <message-id>
 
 Archives a Gmail message by removing the INBOX label. The message remains accessible via search and labels.
 
+### archive-thread — Archive all messages in a thread
+
+```bash
+gws gmail archive-thread <thread-id>
+```
+
+Archives all messages in a Gmail thread by removing the INBOX label and marking all messages as read. Use the `thread_id` from `gws gmail list` output. More efficient than archiving individual messages for multi-message threads.
+
 ### trash — Trash a message
 
 ```bash
@@ -162,5 +171,6 @@ gws gmail list --format text    # Human-readable text
 - Gmail search query syntax supports operators like `is:`, `from:`, `to:`, `subject:`, `after:`, `before:`, `has:`, `label:`
 - When managing labels, run `gws gmail labels` first to see available label names and IDs
 - Archive is a shortcut for `gws gmail label <id> --remove "INBOX"`
+- Use `gws gmail archive-thread <thread-id>` to archive all messages in a conversation at once (archives + marks read)
 - To mark as read: `gws gmail label <id> --remove "UNREAD"`
 - To star a message: `gws gmail label <id> --add "STARRED"`

--- a/skills/gmail/references/commands.md
+++ b/skills/gmail/references/commands.md
@@ -182,6 +182,26 @@ No additional flags. Equivalent to `gws gmail label <id> --remove "INBOX"`.
 
 ---
 
+## gws gmail archive-thread
+
+Archives all messages in a Gmail thread by removing the INBOX label and marking all messages as read.
+
+```
+Usage: gws gmail archive-thread <thread-id>
+```
+
+No additional flags. Use the `thread_id` from `gws gmail list` output. More efficient than archiving individual messages for multi-message threads.
+
+### Output Fields (JSON)
+
+- `status` — Always `"archived"`
+- `thread_id` — Thread ID
+- `archived` — Number of messages successfully archived
+- `failed` — Number of messages that failed to archive
+- `total` — Total messages in the thread
+
+---
+
 ## gws gmail trash
 
 Moves a Gmail message to the trash.


### PR DESCRIPTION
## Summary
- New `gws gmail archive-thread <thread-id>` command
- Fetches thread with minimal format, removes INBOX + UNREAD from all messages in one operation
- Returns structured JSON with archived/failed/total counts
- Updated gmail SKILL.md, references/commands.md, and all test files
- Mock server test validates multi-message thread archiving

## Test plan
- [x] `go test ./cmd/ -run TestGmail -v` — all gmail tests pass including new archive-thread tests
- [x] `go test ./cmd/ -run TestSkillCommands_MatchCLI -v` — skill-CLI cross-reference passes
- [x] `go test ./cmd/ -run TestGmailCommands -v` — command structure test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)