### PR TITLE
Add tasks update command

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -205,6 +205,7 @@ func TestTasksCommands(t *testing.T) {
 		{"lists"},
 		{"list"},
 		{"create"},
+		{"update"},
 		{"complete"},
 	}
 

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -379,7 +379,7 @@ func TestSkillCommands_MatchCLI(t *testing.T) {
 		},
 		"tasks": {
 			parentCmd:   tasksCmd,
-			subcommands: []string{"lists", "list", "create", "complete"},
+			subcommands: []string{"lists", "list", "create", "update", "complete"},
 		},
 		"chat": {
 			parentCmd:   chatCmd,

--- a/cmd/tasks_test.go
+++ b/cmd/tasks_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/tasks/v1"
+)
+
+func TestTasksUpdateCommand_Help(t *testing.T) {
+	cmd := tasksUpdateCmd
+
+	if cmd.Use != "update <tasklist-id> <task-id>" {
+		t.Errorf("unexpected Use: %s", cmd.Use)
+	}
+
+	if cmd.Short == "" {
+		t.Error("expected Short description to be set")
+	}
+
+	if cmd.Args == nil {
+		t.Error("expected Args validator to be set")
+	}
+}
+
+func TestTasksUpdateCommand_Flags(t *testing.T) {
+	cmd := tasksUpdateCmd
+
+	flags := []string{"title", "notes", "due"}
+	for _, flag := range flags {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("expected --%s flag", flag)
+		}
+	}
+}
+
+// TestTasksUpdate_MockServer tests update API integration
+func TestTasksUpdate_MockServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// GET task
+		if r.URL.Path == "/tasks/v1/lists/@default/tasks/task-123" && r.Method == "GET" {
+			resp := &tasks.Task{
+				Id:    "task-123",
+				Title: "Original title",
+				Notes: "Original notes",
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		// PUT (update) task
+		if r.URL.Path == "/tasks/v1/lists/@default/tasks/task-123" && r.Method == "PUT" {
+			var task tasks.Task
+			if err := json.NewDecoder(r.Body).Decode(&task); err != nil {
+				t.Errorf("failed to decode request: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			if task.Title != "Updated title" {
+				t.Errorf("expected title 'Updated title', got '%s'", task.Title)
+			}
+
+			resp := &tasks.Task{
+				Id:    "task-123",
+				Title: task.Title,
+				Notes: task.Notes,
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		t.Logf("Unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	svc, err := tasks.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create tasks service: %v", err)
+	}
+
+	// Get task
+	task, err := svc.Tasks.Get("@default", "task-123").Do()
+	if err != nil {
+		t.Fatalf("failed to get task: %v", err)
+	}
+
+	if task.Title != "Original title" {
+		t.Errorf("unexpected title: %s", task.Title)
+	}
+
+	// Update task
+	task.Title = "Updated title"
+	updated, err := svc.Tasks.Update("@default", "task-123", task).Do()
+	if err != nil {
+		t.Fatalf("failed to update task: %v", err)
+	}
+
+	if updated.Title != "Updated title" {
+		t.Errorf("unexpected updated title: %s", updated.Title)
+	}
+}

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -37,6 +37,7 @@ For initial setup, see the `gws-auth` skill.
 | List with completed | `gws tasks list <tasklist-id> --show-completed` |
 | Create a task | `gws tasks create --title "Buy groceries"` |
 | Create with due date | `gws tasks create --title "Report" --due "2024-02-01"` |
+| Update a task | `gws tasks update <tasklist-id> <task-id> --title "New title"` |
 | Complete a task | `gws tasks complete <tasklist-id> <task-id>` |
 
 ## Detailed Usage
@@ -85,6 +86,25 @@ gws tasks create --title "Finish report" --due "2024-02-01" --notes "Include Q4 
 gws tasks create --title "Team task" --tasklist MTIzNDU2
 ```
 
+### update — Update a task
+
+```bash
+gws tasks update <tasklist-id> <task-id> [flags]
+```
+
+Updates an existing task's title, notes, or due date. At least one of `--title`, `--notes`, or `--due` is required.
+
+**Flags:**
+- `--title string` — New task title
+- `--notes string` — New task notes/description
+- `--due string` — New due date in RFC3339 or `YYYY-MM-DD` format
+
+**Examples:**
+```bash
+gws tasks update @default dGFzay0x --title "Updated title"
+gws tasks update @default dGFzay0x --notes "Added notes" --due "2024-03-01"
+```
+
 ### complete — Mark a task as completed
 
 ```bash
@@ -109,7 +129,7 @@ gws tasks list @default --format text    # Human-readable text
 
 - Always use `--format json` (the default) for programmatic parsing
 - Use `gws tasks lists` first to get task list IDs
-- Use `gws tasks list <tasklist-id>` to get individual task IDs for the `complete` command
+- Use `gws tasks list <tasklist-id>` to get individual task IDs for the `update` and `complete` commands
 - The default task list ID is `@default` — use this when users don't specify a list
 - Due dates accept both RFC3339 (`2024-02-01T00:00:00Z`) and simple date (`2024-02-01`) formats
 - Completed tasks are hidden by default; use `--show-completed` to include them

--- a/skills/tasks/references/commands.md
+++ b/skills/tasks/references/commands.md
@@ -81,6 +81,32 @@ Usage: gws tasks create [flags]
 
 ---
 
+## gws tasks update
+
+Updates an existing task's title, notes, or due date.
+
+```
+Usage: gws tasks update <tasklist-id> <task-id> [flags]
+```
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--title` | string | | No | New task title |
+| `--notes` | string | | No | New task notes/description |
+| `--due` | string | | No | New due date (RFC3339 or `YYYY-MM-DD`) |
+
+At least one of `--title`, `--notes`, or `--due` is required.
+
+### Output Fields (JSON)
+
+- `status` — Always `"updated"`
+- `id` — Task ID
+- `title` — Task title (updated or existing)
+- `notes` — Task notes (if set)
+- `due` — Due date (if set)
+
+---
+
 ## gws tasks complete
 
 Marks a specific task as completed.


### PR DESCRIPTION
## Summary
- New `gws tasks update <tasklist-id> <task-id>` command with `--title`, `--notes`, `--due` flags
- At least one flag required; fetches existing task, applies updates
- New `cmd/tasks_test.go` with command help, flags, and mock server tests
- Updated tasks SKILL.md, references/commands.md, commands_test.go, skills_test.go

## Test plan
- [x] `go test ./cmd/ -run TestTasks -v` — all tasks tests pass
- [x] `go test ./cmd/ -run TestSkillCommands_MatchCLI/tasks -v` — skill-CLI cross-reference passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)