### PR TITLE
Update /morning skill with P0+P1 improvements

### DIFF
--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -697,7 +697,9 @@ func TestMorningSkill_SKILLmdReferencesPrompts(t *testing.T) {
 	// SKILL.md must reference the prompt files it depends on
 	refs := []string{
 		"prompts/batch-classifier.md",
+		"prompts/calendar-coordinator.md",
 		"prompts/deep-dive.md",
+		"prompts/label-resolver.md",
 		"scripts/bulk-gmail.sh",
 	}
 	for _, ref := range refs {

--- a/skills/morning/scripts/bulk-gmail.sh
+++ b/skills/morning/scripts/bulk-gmail.sh
@@ -2,11 +2,13 @@
 # bulk-gmail.sh — Bulk Gmail operations for /morning skill
 #
 # Usage:
-#   bulk-gmail.sh archive <id1> <id2> ...    # archive + mark read
-#   bulk-gmail.sh trash <id1> <id2> ...      # delete + mark read
-#   bulk-gmail.sh mark-read <id1> <id2> ...  # mark read only
+#   bulk-gmail.sh archive <id1> <id2> ...          # archive + mark read (message IDs)
+#   bulk-gmail.sh archive-thread <id1> <id2> ...   # archive thread + mark read (thread IDs)
+#   bulk-gmail.sh trash <id1> <id2> ...             # delete + mark read
+#   bulk-gmail.sh mark-read <id1> <id2> ...         # mark read only
 #
 # All actions except mark-read also mark emails as read.
+# archive-thread uses gws gmail archive-thread (handles all messages in thread).
 # Output: JSON summary { action, total, success, failed }
 
 set -euo pipefail
@@ -15,14 +17,14 @@ ACTION="${1:-}"
 shift 2>/dev/null || true
 
 if [ -z "$ACTION" ] || [ $# -eq 0 ]; then
-  echo '{"error":"Usage: bulk-gmail.sh <archive|trash|mark-read> <id1> [id2] ..."}'
+  echo '{"error":"Usage: bulk-gmail.sh <archive|archive-thread|trash|mark-read> <id1> [id2] ..."}'
   exit 1
 fi
 
 case "$ACTION" in
-  archive|trash|mark-read) ;;
+  archive|archive-thread|trash|mark-read) ;;
   *)
-    echo '{"error":"Unknown action: '"$ACTION"'","valid_actions":["archive","trash","mark-read"]}'
+    echo '{"error":"Unknown action: '"$ACTION"'","valid_actions":["archive","archive-thread","trash","mark-read"]}'
     exit 1
     ;;
 esac
@@ -35,18 +37,22 @@ for id in "$@"; do
 
   case "$ACTION" in
     archive)
-      gws gmail archive "$id" >/dev/null 2>&1 || ok=false
+      gws gmail archive "$id" --quiet >/dev/null 2>&1 || ok=false
+      ;;
+    archive-thread)
+      # archive-thread already marks all messages as read
+      gws gmail archive-thread "$id" --quiet >/dev/null 2>&1 || ok=false
       ;;
     trash)
-      gws gmail trash "$id" >/dev/null 2>&1 || ok=false
+      gws gmail trash "$id" --quiet >/dev/null 2>&1 || ok=false
       ;;
     mark-read)
       ;;
   esac
 
-  # Mark as read (all actions do this)
-  if $ok; then
-    gws gmail label "$id" --remove UNREAD >/dev/null 2>&1 || ok=false
+  # Mark as read (all actions except archive-thread do this; archive-thread handles it)
+  if $ok && [ "$ACTION" != "archive-thread" ]; then
+    gws gmail label "$id" --remove UNREAD --quiet >/dev/null 2>&1 || ok=false
   fi
 
   if $ok; then


### PR DESCRIPTION
## Summary
- Thread-aware archive: `archive-thread` for all archive actions (saves 15-20k tokens/session)
- Calendar scheduling step: spawn calendar-coordinator sub-agent for batch RSVP
- Compound triage options: Label & archive, Add task & archive, Accept & archive
- `--quiet` flag on all archive/label/trash commands to suppress JSON output
- CLI Quick Reference table for common triage commands
- Post-Triage Cleanup step: check for new arrivals after triage
- Calendar `--days 2` for tomorrow's meeting prep context
- Bulk script: add `archive-thread` action with `--quiet` flag
- Tests: SKILL.md now verified to reference all 4 prompt files

## Test plan
- [x] `go test ./cmd/ -run TestMorning -v` — all morning skill tests pass
- [x] `go test ./cmd/ -run TestSkill -v` — all skill tests pass
- [x] `bash -n bulk-gmail.sh` — script syntax valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)