### PR TITLE
Update /morning skill with P2 improvements

### DIFF
--- a/skills/morning/prompts/deep-dive.md
+++ b/skills/morning/prompts/deep-dive.md
@@ -1,6 +1,8 @@
 # Deep-Dive Email Summarizer Prompt
 
-**Model:** `sonnet` — fast, detailed analysis of individual emails.
+**Model:** Chosen by the main agent based on complexity:
+- `haiku` — single-message emails, FYI items, simple questions
+- `sonnet` — multi-message threads (3+), comment notifications, complex action items
 
 **Agent type:** `general-purpose`
 


### PR DESCRIPTION
## Summary
- Deep-dive model guidance: `haiku` for simple, `sonnet` for complex emails (saves tokens on simple lookups)
- Noise handling: numbered batch list with selective archiving ("archive 2,5,8")
- Tasks update docs: document limitation (no cross-list move) and workaround
- Label operations docs: display name resolution, label-resolver sub-agent usage
- Updated deep-dive.md model declaration

## Test plan
- [x] `go test ./cmd/ -run TestMorning -v` — all morning skill tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)