### PR TITLE
Bump versions: morning skill 0.2.0, CLI 1.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.2.2** - Fix `go install` version detection via debug.ReadBuildInfo(). Full CRUD for all services.
+**v1.3.0** - Morning skill v0.2.0 improvements, `archive-thread`, `tasks update`, `--quiet` flag.
 
 ## Roadmap
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.2.2
+VERSION ?= 1.3.0
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/skills/morning/SKILL.md
+++ b/skills/morning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gws-morning
-version: 0.1.0
+version: 0.2.0
 description: "AI-powered morning inbox briefing. Reads Gmail, Google Tasks, Calendar, and OKR sheets to produce a prioritized daily briefing with actionable recommendations. Triggers: /morning, morning briefing, inbox triage, email priorities, daily digest."
 metadata:
   short-description: AI inbox briefing with OKR/task matching


### PR DESCRIPTION
## Summary
- Morning skill `0.1.0` → `0.2.0` (SKILL.md frontmatter)
- CLI `1.2.2` → `1.3.0` (Makefile VERSION)
- CLAUDE.md version reference updated

### Morning skill 0.2.0 changes (PRs #18-#26):
- Calendar-coordinator sub-agent prompt
- Label-resolver sub-agent prompt
- Compact-prompt tracked in git
- Thread-aware archive, compound options, scheduling step
- `--quiet` flag, CLI quick reference, post-triage cleanup
- Deep-dive model guidance, numbered noise list, task/label tips
- Batch classifier self-gathering rewrite

### CLI 1.3.0 changes (PRs #21-#23):
- `gws gmail archive-thread <thread-id>`
- `gws tasks update <tasklist-id> <task-id>`
- `--quiet` global flag with NullPrinter

## Test plan
- [x] `go test ./...` — full test suite passes
- [x] `make build && ./bin/gws version` — shows v1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)