### PR TITLE
Fix review findings from retroactive PR reviews

### DIFF
--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -390,7 +390,7 @@ func resolveLabelNames(svc *gmail.Service, names []string) ([]string, error) {
 }
 
 func runGmailLabel(cmd *cobra.Command, args []string) error {
-	p := printer.New(os.Stdout, GetFormat())
+	p := GetPrinter()
 	ctx := context.Background()
 
 	factory, err := client.NewFactory(ctx)
@@ -448,7 +448,7 @@ func runGmailLabel(cmd *cobra.Command, args []string) error {
 }
 
 func runGmailArchive(cmd *cobra.Command, args []string) error {
-	p := printer.New(os.Stdout, GetFormat())
+	p := GetPrinter()
 	ctx := context.Background()
 
 	factory, err := client.NewFactory(ctx)
@@ -480,7 +480,7 @@ func runGmailArchive(cmd *cobra.Command, args []string) error {
 }
 
 func runGmailArchiveThread(cmd *cobra.Command, args []string) error {
-	p := printer.New(os.Stdout, GetFormat())
+	p := GetPrinter()
 	ctx := context.Background()
 
 	factory, err := client.NewFactory(ctx)
@@ -526,7 +526,7 @@ func runGmailArchiveThread(cmd *cobra.Command, args []string) error {
 }
 
 func runGmailTrash(cmd *cobra.Command, args []string) error {
-	p := printer.New(os.Stdout, GetFormat())
+	p := GetPrinter()
 	ctx := context.Background()
 
 	factory, err := client.NewFactory(ctx)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -59,7 +59,7 @@ func TestNullPrinter_ImplementsPrinter(t *testing.T) {
 
 func TestNullPrinter_SuppressesOutput(t *testing.T) {
 	null := NewNullPrinter()
-	json := NewJSONPrinter(&bytes.Buffer{})
+	jsonPrinter := NewJSONPrinter(&bytes.Buffer{})
 
 	data := map[string]interface{}{
 		"thread_id": "abc-123",
@@ -68,8 +68,7 @@ func TestNullPrinter_SuppressesOutput(t *testing.T) {
 	}
 
 	// NullPrinter produces no output; JSONPrinter does
-	// We can't capture NullPrinter's stdout since it doesn't write anywhere,
-	// but we verify it handles all the same data types without error
+	// We verify both handle all data types without error
 	types := []interface{}{
 		data,
 		"simple string",
@@ -84,25 +83,24 @@ func TestNullPrinter_SuppressesOutput(t *testing.T) {
 			if printErr := null.PrintError(err); printErr != nil {
 				t.Errorf("NullPrinter.PrintError failed for %T: %v", v, printErr)
 			}
-			if printErr := json.PrintError(err); printErr != nil {
+			if printErr := jsonPrinter.PrintError(err); printErr != nil {
 				t.Errorf("JSONPrinter.PrintError failed for %T: %v", v, printErr)
 			}
 		} else {
 			if err := null.Print(v); err != nil {
 				t.Errorf("NullPrinter.Print failed for %T: %v", v, err)
 			}
-			if err := json.Print(v); err != nil {
+			if err := jsonPrinter.Print(v); err != nil {
 				t.Errorf("JSONPrinter.Print failed for %T: %v", v, err)
 			}
 		}
 	}
 }
 
-func TestNullPrinter_ProducesNoBytes(t *testing.T) {
-	// NullPrinter has no writer — verify it doesn't panic or write anywhere
+func TestNullPrinter_HandlesLargeData(t *testing.T) {
+	// Verify NullPrinter doesn't panic with large data
 	p := NewNullPrinter()
 
-	// Large data that would normally produce significant output
 	largeData := make(map[string]interface{})
 	for i := 0; i < 100; i++ {
 		largeData[strings.Repeat("key", i+1)] = strings.Repeat("value", i+1)

--- a/skills/morning/prompts/batch-classifier.md
+++ b/skills/morning/prompts/batch-classifier.md
@@ -19,8 +19,8 @@ Run these commands to collect all context. Run them in parallel where possible.
 
 ### Inbox
 
-gws gmail list --max <max_emails> --query "is:unread"
-gws gmail list --max <max_emails> --query "is:unread category:promotions"
+gws gmail list --max <max_emails> --query "<inbox_query>"
+gws gmail list --max <max_emails> --query "<inbox_query> category:promotions"
 
 Cross-reference the two lists by thread_id to separate PRIMARY (not in promotions) from NOISE (in promotions).
 
@@ -45,6 +45,11 @@ Using the gathered data, classify each PRIMARY email (not noise).
 ### Config
 
 <The main agent passes these values when spawning:>
+- max_emails: <number from config, default 50>
+- inbox_query: <query from config, default "is:unread">
+- Task list IDs: <list of IDs, or "all" — if "all", run `gws tasks lists` first to discover IDs>
+- OKR sheet ID: <sheet_id>
+- OKR sheet names: <list of sheet tab names>
 - VIP senders: <list with role annotations>
 - Priority signals: starred = <true/false>
 - Noise strategy: <promotions or custom>
@@ -112,6 +117,16 @@ At the end, include:
 - OVERDUE TASKS list (from task data)
 - TODAY'S MEETINGS list (from calendar data) with any email cross-references
 ```
+
+## Error Handling
+
+If a `gws` command fails:
+- **Inbox commands fail** — return an error; classification cannot proceed without inbox data
+- **Tasks command fails** — continue without task matching; note in output that task data was unavailable
+- **Calendar command fails** — continue without calendar matching; note in output
+- **OKR command fails** — continue without OKR matching; note in output
+
+Always attempt all data sources. Partial data is better than no classification.
 
 ## How the Main Agent Uses This
 

--- a/skills/morning/prompts/calendar-coordinator.md
+++ b/skills/morning/prompts/calendar-coordinator.md
@@ -54,12 +54,10 @@ For each matched event:
 
 For ACCEPT items:
 gws calendar rsvp <event-id> --response accepted
-gws gmail archive <message-id> >/dev/null 2>&1
-gws gmail label <message-id> --remove UNREAD >/dev/null 2>&1
+gws gmail archive-thread <thread-id> --quiet >/dev/null 2>&1
 
 For CANCELED and PAST items:
-gws gmail archive <message-id> >/dev/null 2>&1
-gws gmail label <message-id> --remove UNREAD >/dev/null 2>&1
+gws gmail archive-thread <thread-id> --quiet >/dev/null 2>&1
 
 For CONFLICT and OUT_OF_RANGE items:
 Do NOT take action. Report them for user decision.
@@ -94,7 +92,7 @@ TOTAL PROCESSED: <N> | AUTO-ACCEPTED: <N> | NEEDS ATTENTION: <N> | ARCHIVED: <N>
 
 - Run gws commands to fetch calendar data and execute RSVPs/archives
 - Do NOT RSVP to conflicting events — the user must decide
-- Always archive + mark read for handled items (accepted, canceled, past)
+- Always archive + mark read for handled items (accepted, canceled, past) using `archive-thread --quiet`
 - Be conservative: if unsure about a match, classify as OUT_OF_RANGE
 - Return ONLY the structured summary, not raw API output
 ```

--- a/skills/morning/prompts/label-resolver.md
+++ b/skills/morning/prompts/label-resolver.md
@@ -14,6 +14,7 @@ You are a Gmail label resolver agent. Your job: find the best matching label for
 ## INPUT
 
 - message_id: <message_id>
+- thread_id: <thread_id> (required if action is "archive")
 - desired_label: <label name — may be fuzzy, partial, or case-insensitive>
 - action: <"archive" | "mark-read" | "none">
 
@@ -37,15 +38,15 @@ Match the desired label name against the label list:
 ### 3. Apply Label
 
 Run:
-gws gmail label <message_id> --add "<matched_label_name>"
+gws gmail label <message_id> --add "<matched_label_name>" --quiet >/dev/null 2>&1
 
 ### 4. Additional Actions
 
 If action is "archive":
-gws gmail archive <message_id> >/dev/null 2>&1
+gws gmail archive-thread <thread_id> --quiet >/dev/null 2>&1
 
 If action is "archive" or "mark-read":
-gws gmail label <message_id> --remove UNREAD >/dev/null 2>&1
+gws gmail label <message_id> --remove UNREAD --quiet >/dev/null 2>&1
 
 ## OUTPUT FORMAT
 
@@ -63,6 +64,8 @@ suggestions: ["<closest match 1>", "<closest match 2>"]
 ## INSTRUCTIONS
 
 - Run gws commands to fetch labels and apply them
+- Use `--quiet` on all gws commands to suppress JSON output
+- Use `archive-thread` (not `archive`) when archiving — this handles all messages in the thread
 - Be conservative with fuzzy matching — prefer exact matches
 - Do NOT create new labels, only apply existing ones
 - Return ONLY the structured summary


### PR DESCRIPTION
## Summary

Fixes all issues identified during retroactive code reviews of PRs #18-#28.

**Critical:**
- SKILL.md Steps 2-3 contradicted the self-gather batch classifier design (PR #26), causing double data fetching. Main agent now only gathers calendar data; the batch classifier sub-agent gathers inbox/tasks/OKRs itself.

**Medium:**
- Migrate gmail `archive`, `archive-thread`, `label`, `trash` commands to use `GetPrinter()` so `--quiet` flag actually suppresses output
- Update `calendar-coordinator.md` and `label-resolver.md` prompts to use `--quiet` and `archive-thread` instead of message-level archive

**Low:**
- Fix `tasks update` to use `cmd.Flags().Changed()` instead of `== ""`, enabling clearing fields to empty string
- Fix digest mode table, CLI quick reference, and tips to reference `archive-thread`
- Add `inbox_query` config support and error handling guidance to batch classifier
- Fix misleading test names and `json` package shadowing in printer tests

## Files changed (8)

| File | Change |
|------|--------|
| `skills/morning/SKILL.md` | Steps 2-3 rewrite, digest table, quick ref, tips |
| `skills/morning/prompts/batch-classifier.md` | Config params, inbox_query, error handling |
| `skills/morning/prompts/calendar-coordinator.md` | `--quiet` + `archive-thread` |
| `skills/morning/prompts/label-resolver.md` | `--quiet` + `archive-thread` + thread_id input |
| `cmd/gmail.go` | Migrate 4 commands to `GetPrinter()` |
| `cmd/tasks.go` | `Flags().Changed()` + validation before client |
| `cmd/tasks_test.go` | Rename + add no-flags-returns-early test |
| `internal/printer/printer_test.go` | Fix shadowing + rename misleading tests |

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Verify `gws gmail archive <id> --quiet` suppresses output
- [ ] Verify `gws tasks update @default <id> --notes ""` clears notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)