### PR TITLE
Fix inbox query to use in:inbox and add max_unread config

### DIFF
--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -709,6 +709,29 @@ func TestMorningSkill_SKILLmdReferencesPrompts(t *testing.T) {
 	}
 }
 
+func TestMorningSkill_InboxQueryUsesInInbox(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(skillsDir(t), "morning", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("failed to read morning SKILL.md: %v", err)
+	}
+	content := string(data)
+
+	// The default inbox query MUST include "in:inbox" to avoid surfacing archived emails
+	if !strings.Contains(content, `"is:unread in:inbox"`) {
+		t.Error("morning SKILL.md inbox_query default must include 'in:inbox'")
+	}
+
+	// Config template should also use in:inbox
+	if !strings.Contains(content, `inbox_query: "is:unread in:inbox"`) {
+		t.Error("morning SKILL.md config template inbox_query must include 'in:inbox'")
+	}
+
+	// max_unread config must be documented
+	if !strings.Contains(content, "max_unread") {
+		t.Error("morning SKILL.md missing max_unread config documentation")
+	}
+}
+
 func TestMorningSkill_HasBlockerDetection(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(skillsDir(t), "morning", "SKILL.md"))
 	if err != nil {

--- a/skills/morning/SKILL.md
+++ b/skills/morning/SKILL.md
@@ -51,8 +51,8 @@ The config contains:
 - `priority_signals` — Signals that boost priority:
   - `starred: true` — Starred emails get a priority boost
   - `vip_senders` — List of email addresses whose emails are always prioritized (manager, direct reports, department heads, key partners)
-- `inbox_query` — Gmail search query (default: `"is:unread"`)
-- `max_emails` — How many unread emails to analyze (default 50)
+- `max_unread` — How many unread inbox emails to fetch (default 50, configurable)
+- `inbox_query` — Gmail search query (default: `"is:unread in:inbox"`)
 - `daily_log_doc_id` — Google Doc ID for the daily log (empty = skip logging)
 
 ## Step 2: Gather Context for Summary Header
@@ -80,12 +80,12 @@ Fetch **2 days** (today + tomorrow) for meeting prep context. Extract: event tit
 **Model:** `sonnet` | **Agent type:** `general-purpose`
 
 Follow the prompt template in the file. Pass config values only:
-- `max_emails` — from config
+- `max_unread` — from config (default 50)
 - Task list IDs — from config (`task_lists`)
 - OKR sheet ID and sheet names — from config
 - VIP senders — from config (`priority_signals.vip_senders`)
 - Noise strategy — from config
-- `inbox_query` — from config (default: `"is:unread"`)
+- `inbox_query` — from config (default: `"is:unread in:inbox"`)
 
 The sub-agent fetches inbox, tasks, and OKRs itself. **Do NOT pass raw data.**
 
@@ -494,8 +494,8 @@ priority_signals:
     # Department heads
     - dept_head@company.com
 
-inbox_query: "is:unread"
-max_emails: 50
+inbox_query: "is:unread in:inbox"
+max_unread: 50
 
 daily_log_doc_id: ""
 ```
@@ -506,7 +506,7 @@ Common `gws` commands used during triage:
 
 | Action | Command |
 |--------|---------|
-| List unread | `gws gmail list --max 50 --query "is:unread"` |
+| List unread | `gws gmail list --max 50 --query "is:unread in:inbox"` |
 | Read message | `gws gmail read <message-id>` |
 | Read thread | `gws gmail thread <thread-id>` |
 | Archive thread | `gws gmail archive-thread <thread-id> --quiet` |

--- a/skills/morning/prompts/batch-classifier.md
+++ b/skills/morning/prompts/batch-classifier.md
@@ -19,8 +19,8 @@ Run these commands to collect all context. Run them in parallel where possible.
 
 ### Inbox
 
-gws gmail list --max <max_emails> --query "<inbox_query>"
-gws gmail list --max <max_emails> --query "<inbox_query> category:promotions"
+gws gmail list --max <max_unread> --query "<inbox_query>"
+gws gmail list --max <max_unread> --query "<inbox_query> category:promotions"
 
 Cross-reference the two lists by thread_id to separate PRIMARY (not in promotions) from NOISE (in promotions).
 
@@ -45,8 +45,8 @@ Using the gathered data, classify each PRIMARY email (not noise).
 ### Config
 
 <The main agent passes these values when spawning:>
-- max_emails: <number from config, default 50>
-- inbox_query: <query from config, default "is:unread">
+- max_unread: <number from config, default 50>
+- inbox_query: <query from config, default "is:unread in:inbox">
 - Task list IDs: <list of IDs, or "all" — if "all", run `gws tasks lists` first to discover IDs>
 - OKR sheet ID: <sheet_id>
 - OKR sheet names: <list of sheet tab names>
@@ -131,7 +131,7 @@ Always attempt all data sources. Partial data is better than no classification.
 ## How the Main Agent Uses This
 
 The main agent spawns this sub-agent with:
-1. Config values: max_emails, task list IDs, OKR sheet ID/names, VIP senders, noise strategy
+1. Config values: max_unread, task list IDs, OKR sheet ID/names, VIP senders, noise strategy
 2. No raw data — the sub-agent fetches everything itself
 
 The sub-agent returns structured classification. The main agent never sees the raw JSON from gws commands — only the classified output enters the main conversation context. This saves ~20-30k tokens per session.


### PR DESCRIPTION
## Summary
- Fixed default `inbox_query` from `"is:unread"` to `"is:unread in:inbox"` — prevents surfacing archived emails from months ago
- Renamed `max_emails` to `max_unread` for clarity (default 50, configurable)
- Updated all references in SKILL.md, batch-classifier prompt, and CLI quick reference
- Added test to validate the query includes `in:inbox`

## Test plan
- [x] `go test ./...` passes
- [x] New `TestMorningSkill_InboxQueryUsesInInbox` validates the fix
- [ ] Manual QA: run `/morning` and verify only inbox emails appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)