### PR TITLE
Rewrite morning skill to parallel triage architecture

### DIFF
--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -588,6 +588,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 		"morning/prompts/calendar-coordinator.md",
 		"morning/prompts/deep-dive.md",
 		"morning/prompts/label-resolver.md",
+		"morning/prompts/triage-agent.md",
 		"morning/scripts/bulk-gmail.sh",
 	}
 	for _, f := range morningExtras {
@@ -596,7 +597,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 		}
 	}
 
-	expectedTotal := 30 // 1 marketplace.json + 12 SKILL.md + 10 commands.md + 1 setup-guide.md + 6 morning extras
+	expectedTotal := 31 // 1 marketplace.json + 12 SKILL.md + 10 commands.md + 1 setup-guide.md + 7 morning extras
 	if count != expectedTotal {
 		t.Errorf("expected %d skill files, found %d", expectedTotal, count)
 	}
@@ -607,10 +608,12 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 func TestMorningSkill_PromptFilesExist(t *testing.T) {
 	base := skillsDir(t)
 	prompts := []string{
-		"prompts/batch-classifier.md",
-		"prompts/calendar-coordinator.md",
+		"prompts/triage-agent.md",
 		"prompts/deep-dive.md",
 		"prompts/label-resolver.md",
+		// Deprecated but kept for reference:
+		"prompts/batch-classifier.md",
+		"prompts/calendar-coordinator.md",
 	}
 	for _, p := range prompts {
 		path := filepath.Join(base, "morning", p)
@@ -623,10 +626,12 @@ func TestMorningSkill_PromptFilesExist(t *testing.T) {
 func TestMorningSkill_PromptFilesSpecifyModel(t *testing.T) {
 	base := skillsDir(t)
 	prompts := map[string]string{
-		"prompts/batch-classifier.md":      "sonnet",
-		"prompts/calendar-coordinator.md":  "sonnet",
+		"prompts/triage-agent.md":          "sonnet",
 		"prompts/deep-dive.md":             "sonnet",
 		"prompts/label-resolver.md":        "haiku",
+		// Deprecated prompts still checked for consistency:
+		"prompts/batch-classifier.md":      "sonnet",
+		"prompts/calendar-coordinator.md":  "sonnet",
 	}
 	for file, expectedModel := range prompts {
 		t.Run(file, func(t *testing.T) {
@@ -696,8 +701,7 @@ func TestMorningSkill_SKILLmdReferencesPrompts(t *testing.T) {
 
 	// SKILL.md must reference the prompt files it depends on
 	refs := []string{
-		"prompts/batch-classifier.md",
-		"prompts/calendar-coordinator.md",
+		"prompts/triage-agent.md",
 		"prompts/deep-dive.md",
 		"prompts/label-resolver.md",
 		"scripts/bulk-gmail.sh",

--- a/skills/morning/compact-prompt.md
+++ b/skills/morning/compact-prompt.md
@@ -15,10 +15,17 @@ Resume a /morning inbox triage session. Run /gws:morning to load the skill, then
 - OKR sheet: <sheet_id> — <sheet_names>
 - VIP senders: <list>
 - Noise strategy: promotions
+- max_unread: <N>
 
-## Batch Classification Results
+## Triage Agent Results
 
-The batch classifier already ran. Here are the results (do NOT re-fetch or re-classify):
+Parallel triage agents already ran. Here are the merged results (do NOT re-fetch or re-classify):
+
+### Auto-Handled (<N> items)
+- Noise archived: <N>
+- Stale scheduling archived: <N>
+- Invites accepted (no conflict): <N>
+- Past events archived: <N>
 
 ### ACT NOW (<N> items)
 | # | ID | From | Subject | Priority | OKR/Task Match | Status |
@@ -30,20 +37,6 @@ The batch classifier already ran. Here are the results (do NOT re-fetch or re-cl
 | # | ID | From | Subject | Priority | OKR/Task Match | Status |
 |---|-----|------|---------|----------|----------------|--------|
 ...
-
-### SCHEDULING (<N> items)
-| # | ID | From | Subject | Status |
-|---|-----|------|---------|--------|
-...
-
-### PERIPHERAL (<N> items)
-| # | ID | From | Subject | Status |
-|---|-----|------|---------|--------|
-...
-
-### NOISE (<N> items)
-<N> promotions, <N> non-promo noise. IDs: <comma-separated message_ids>
-Status: <NOT HANDLED / Archived all / Partially handled>
 
 ## Actions Taken So Far
 
@@ -75,7 +68,7 @@ Continue from: **<CATEGORY> item [<N>/<TOTAL>]** — <sender — subject>
 
 ## How to Fill This In
 
-1. **Batch classification**: Copy the structured output from the batch classifier sub-agent. Mark each item as DONE (with action) or PENDING.
+1. **Triage results**: Copy the merged output from parallel triage agents. The auto-handled section shows what was archived/accepted automatically. Mark ACT NOW / REVIEW items as DONE (with action) or PENDING.
 2. **Actions taken**: List every email you acted on — archive, star, task, open, delete. Note if marked read.
 3. **Resume point**: Identify exactly where triage stopped — category, item number, and whether the user was mid-decision.
 4. **Corrections**: Any time the user corrected a classification (e.g., "that's not ACT NOW, I'm CC'd"), note it so the resumed session doesn't repeat the mistake.

--- a/skills/morning/prompts/deep-dive.md
+++ b/skills/morning/prompts/deep-dive.md
@@ -1,8 +1,6 @@
 # Deep-Dive Email Summarizer Prompt
 
-**Model:** Chosen by the main agent based on complexity:
-- `haiku` — single-message emails, FYI items, simple questions
-- `sonnet` — multi-message threads (3+), comment notifications, complex action items
+**Model:** `sonnet` — always use sonnet. Haiku is unreliable for email reading (fails to fetch content in practice).
 
 **Agent type:** `general-purpose`
 

--- a/skills/morning/prompts/triage-agent.md
+++ b/skills/morning/prompts/triage-agent.md
@@ -1,0 +1,157 @@
+# Triage Agent Prompt
+
+**Model:** `sonnet` — needs classification logic, calendar conflict checking, and autonomous action execution.
+
+**Agent type:** `general-purpose`
+
+**Purpose:** Process a batch of 5-10 emails from the inbox. For each email: classify, score priority, and take autonomous action where possible. Noise and stale scheduling items are auto-archived. Only ACT_NOW and REVIEW items are returned for the main agent to present to the user.
+
+Replaces the v0.2.0 batch-classifier and calendar-coordinator as a single unified agent that classifies AND acts.
+
+## Prompt Template
+
+```
+You are a triage agent for an inbox briefing skill. You receive a batch of email summaries and context data. For each email, classify it, score priority, and take autonomous action when appropriate.
+
+## INPUT
+
+You receive:
+- A batch of email summaries (5-10 emails) with: message_id, thread_id, subject, sender, snippet, labels, message_count, date
+- Calendar events for the next 2 days (pre-fetched by main agent)
+- Task list data (pre-fetched by main agent)
+- OKR context (pre-fetched by main agent)
+- VIP senders list
+- Config: noise_strategy, priority signals
+
+## CLASSIFICATION CATEGORIES
+
+| Category | Criteria |
+|----------|----------|
+| ACT_NOW | Direct question to the user, approval/review request. User MUST be the blocker — not just CC'd. |
+| REVIEW | FYI-relevant, decision context, user is CC'd on active thread, relates to OKR/task/meeting |
+| SCHEDULING | Calendar invites, meeting updates, reschedules |
+| NOISE | Gmail Promotions category, newsletters, automated alerts, digests, resolved comment notifications |
+
+**Flat classification — no promo/non-promo split.** All noise is noise regardless of source.
+
+### Blocker Detection (Critical)
+
+For multi-message threads and CC'd emails, determine WHO OWNS THE NEXT ACTION:
+- User is the blocker → ACT_NOW
+- User is CC'd, someone else is the blocker → REVIEW (not ACT_NOW)
+- User is TO'd but ask is to a group → REVIEW (unless explicitly named)
+
+### Google Docs/Slides/Sheets Comment Notifications
+
+Parse email snippet/subject for resolution status:
+- "N resolved" → comment is resolved → NOISE (auto-archive)
+- Someone already replied → REVIEW (not ACT_NOW)
+- Open comment, user expected to respond → ACT_NOW
+
+### Priority Scoring (1-5)
+
+| Signal | Score |
+|--------|-------|
+| Top 5 task match | 5 |
+| Overdue task link | 5 |
+| Must Win / OKR match | 4 |
+| VIP sender + action required | 4 |
+| Meeting prep (today's calendar) | 4 |
+| Starred email | 4 |
+| Active task match | 3 |
+| VIP sender (FYI) | 3 |
+| Action required (non-VIP) | 3 |
+| Time sensitivity | 3 |
+| Thread momentum | 2 |
+| FYI peripheral | 1 |
+| Noise | 0 |
+
+Use the HIGHEST signal score (not additive).
+
+## AUTONOMOUS ACTIONS
+
+After classifying each email, take action autonomously for these categories:
+
+### NOISE → Auto-archive
+```bash
+gws gmail archive-thread <thread_id> --quiet
+```
+
+### SCHEDULING — Stale/Past Events → Auto-archive
+If the scheduling email refers to an event in the past:
+```bash
+gws gmail archive-thread <thread_id> --quiet
+```
+
+### SCHEDULING — Future Events, No Conflict → Auto-accept + archive
+1. Check the calendar events data for conflicts (overlapping time ranges, excluding all-day events)
+2. If no conflict found:
+```bash
+gws calendar rsvp <event-id> --response accepted
+gws gmail archive-thread <thread_id> --quiet
+```
+3. If conflict found → return as REVIEW with conflict details
+
+### SCHEDULING — Canceled Events → Auto-archive
+If subject contains "Canceled:" or email indicates cancellation:
+```bash
+gws gmail archive-thread <thread_id> --quiet
+```
+
+### ACT_NOW / REVIEW → Do NOT take action
+Return these to the main agent with summary and recommended action.
+
+## IMPORTANT RULES
+
+- MUST use `archive-thread` (not `archive`) — handles all messages in the thread
+- MUST use `--quiet` on all gws commands to suppress output
+- MUST NOT ask the user anything — you are autonomous
+- MUST return structured JSON output, not raw API responses
+- MUST process ALL emails in the batch — do not skip any
+- Single flat list of IDs — no promo vs non-promo separation
+
+## OUTPUT FORMAT
+
+Return a JSON array. For each email in the batch:
+
+```json
+[
+  {
+    "message_id": "<id>",
+    "thread_id": "<id>",
+    "subject": "<subject>",
+    "sender": "<sender>",
+    "classification": "ACT_NOW | REVIEW | SCHEDULING | NOISE",
+    "priority": 1-5,
+    "action_taken": "archived | accepted_and_archived | none",
+    "summary": "2-3 line summary: what it's about, who's involved, why it matters",
+    "okr_match": "<OKR objective or null>",
+    "task_match": "<task title or null>",
+    "calendar_match": "<event title or null>",
+    "recommended_action": "Reply to X about Y | Archive | Add task | Monitor | null"
+  }
+]
+```
+
+At the end, include a summary object:
+
+```json
+{
+  "batch_summary": {
+    "total": <N>,
+    "auto_archived_noise": <N>,
+    "auto_archived_stale_scheduling": <N>,
+    "auto_accepted_invites": <N>,
+    "needs_user_input": <N>,
+    "act_now_count": <N>,
+    "review_count": <N>
+  }
+}
+```
+
+## ERROR HANDLING
+
+- If a `gws` command fails (archive, RSVP), set `action_taken` to `"failed:<reason>"` and return the email for user handling
+- Continue processing remaining emails even if one fails
+- If calendar event ID cannot be determined from the email, classify as REVIEW with note "could not match to calendar event"
+```


### PR DESCRIPTION
## Summary
- **Architecture rewrite:** Replace sequential batch-classifier with parallel triage agents that classify AND act autonomously
- **New `triage-agent.md`** replaces `batch-classifier.md` + `calendar-coordinator.md` — one unified agent per batch of 5-10 emails
- **Parallel execution:** Main agent gathers all data in ~10s, spawns triage agents in parallel, user sees header immediately
- **Autonomous actions:** Noise → auto-archive, stale scheduling → auto-archive, no-conflict invites → auto-accept+archive
- **Only ACT_NOW + REVIEW items reach the user** — reduces interactions from 35-40 to 5-15
- **Deep-dive always uses sonnet** — haiku failed in QA for email reading
- **Post-triage cleanup is now MANDATORY** (was skipped in v0.2.0)
- **Single flat ID list** — no promo/non-promo split (addresses #31)

## Files changed
| File | Change |
|------|--------|
| `skills/morning/SKILL.md` | Major rewrite: Steps 2-8 for parallel architecture |
| `skills/morning/prompts/triage-agent.md` | **NEW** — per-batch triage agent prompt |
| `skills/morning/prompts/deep-dive.md` | Sonnet only (removed haiku option) |
| `skills/morning/compact-prompt.md` | Updated for new architecture |
| `cmd/skills_test.go` | Updated prompt file lists, file counts |

## Expected outcomes
| Metric | v0.2.0 | v0.3.0 |
|--------|--------|--------|
| Time to first content | ~3.5 min | ~10 sec |
| Total triage time (50 emails) | 15-25 min | 5-10 min |
| User interactions | 35-40 | 5-15 |
| Main context usage | ~70% | ~30-40% |

## Test plan
- [x] `go test ./...` passes
- [x] All prompt files exist and specify models
- [x] SKILL.md references triage-agent.md
- [x] File count updated to 31 (added triage-agent.md)
- [ ] Manual QA: run `/morning` and verify parallel triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)