### PR TITLE
Bump morning skill version to 0.3.0

### DIFF
--- a/skills/morning/SKILL.md
+++ b/skills/morning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gws-morning
-version: 0.2.0
+version: 0.3.0
 description: "AI-powered morning inbox briefing. Reads Gmail, Google Tasks, Calendar, and OKR sheets to produce a prioritized daily briefing with actionable recommendations. Triggers: /morning, morning briefing, inbox triage, email priorities, daily digest."
 metadata:
   short-description: AI inbox briefing with OKR/task matching


### PR DESCRIPTION
## Summary
- Bumps morning skill frontmatter version from `0.2.0` to `0.3.0`
- Reflects the parallel triage architecture rewrite (PR #33)
- CLI version stays at `1.4.0` — no Go code changes in this release

## Test plan
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)