### PR TITLE
Fix PR #33 review findings: event matching, deprecation headers

### DIFF
--- a/skills/morning/prompts/batch-classifier.md
+++ b/skills/morning/prompts/batch-classifier.md
@@ -1,5 +1,7 @@
 # Batch Email Classifier Prompt
 
+> **DEPRECATED (v0.3.0):** Replaced by `triage-agent.md` which classifies AND acts autonomously in parallel batches. Kept for reference only.
+
 **Model:** `sonnet` — fast structured output, cost-effective for bulk classification.
 
 **Agent type:** `general-purpose`

--- a/skills/morning/prompts/calendar-coordinator.md
+++ b/skills/morning/prompts/calendar-coordinator.md
@@ -1,5 +1,7 @@
 # Calendar Coordinator Prompt
 
+> **DEPRECATED (v0.3.0):** Calendar coordination is now handled by `triage-agent.md` which matches invites, checks conflicts, and RSVPs autonomously. Kept for reference only.
+
 **Model:** `sonnet` — needs conflict checking logic and calendar event matching.
 
 **Agent type:** `general-purpose`

--- a/skills/morning/prompts/triage-agent.md
+++ b/skills/morning/prompts/triage-agent.md
@@ -84,13 +84,23 @@ gws gmail archive-thread <thread_id> --quiet
 ```
 
 ### SCHEDULING — Future Events, No Conflict → Auto-accept + archive
-1. Check the calendar events data for conflicts (overlapping time ranges, excluding all-day events)
+
+**Matching email to calendar event:**
+Match the invite email to the pre-fetched calendar events by:
+- Title similarity (fuzzy — "Q2 Planning" matches "Q2 Planning Session")
+- Date/time alignment (email mentions same date as event)
+- Sender appears in the event's attendees or organizer field
+
+If no matching event is found in the calendar data, classify as REVIEW with note "could not match to calendar event — accept manually".
+
+**Conflict check and RSVP:**
+1. Check the matched event's time range against ALL other events (excluding all-day events)
 2. If no conflict found:
 ```bash
 gws calendar rsvp <event-id> --response accepted
 gws gmail archive-thread <thread_id> --quiet
 ```
-3. If conflict found → return as REVIEW with conflict details
+3. If conflict found → return as REVIEW with conflict details (conflicting event title + time)
 
 ### SCHEDULING — Canceled Events → Auto-archive
 If subject contains "Canceled:" or email indicates cancellation:
@@ -121,7 +131,7 @@ Return a JSON array. For each email in the batch:
     "thread_id": "<id>",
     "subject": "<subject>",
     "sender": "<sender>",
-    "classification": "ACT_NOW | REVIEW | SCHEDULING | NOISE",
+    "classification": "ACT_NOW | REVIEW | NOISE",
     "priority": 1-5,
     "action_taken": "archived | accepted_and_archived | none",
     "summary": "2-3 line summary: what it's about, who's involved, why it matters",


### PR DESCRIPTION
## Summary
Addresses code review findings from PR #33:
- **Event-ID matching guidance** in `triage-agent.md` — explains how to match invite emails to calendar events (fuzzy title, date/time, sender-in-attendees)
- **Cleaned output enum** — removed `SCHEDULING` from classification output (resolved items become REVIEW or are auto-archived)
- **Deprecation headers** on `batch-classifier.md` and `calendar-coordinator.md` — clearly marks them as superseded by `triage-agent.md`

## Test plan
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)