### PR TITLE
fix: normalize YYYY-MM-DD due dates to RFC3339

### DIFF
--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gws-tasks
-version: 1.0.0
+version: 1.0.1
 description: "Google Tasks CLI operations via gws. Use when users need to manage task lists, view tasks, create tasks, or mark tasks complete. Triggers: google tasks, task list, todo, task management."
 metadata:
   short-description: Google Tasks CLI operations


### PR DESCRIPTION
## Summary
- `--due "2026-02-05"` was passed directly to Google Tasks API which requires RFC3339, causing 400 errors
- Added `normalizeDueDate()` helper that converts `YYYY-MM-DD` → `YYYY-MM-DDT00:00:00Z`
- Applied to both `create` and `update` commands
- Bumped skill version to 1.0.1

## Test plan
- [x] Unit tests for `normalizeDueDate` (YYYY-MM-DD, RFC3339 passthrough, non-matching formats)
- [x] Manual test: `gws tasks create --title "test" --due "2026-02-05"` succeeds
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)