### PR TITLE
feat(gmail): add pagination support for list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add `--format text` to any command for human-readable output.
 
 | Command | Description |
 |---------|-------------|
-| `gws gmail list` | List threads with `thread_id` and `message_id` (`--max`, `--query`) |
+| `gws gmail list` | List threads with `thread_id` and `message_id` (`--max`, `--query`, `--all` for pagination) |
 | `gws gmail read <id>` | Read message body and headers |
 | `gws gmail thread <id>` | Read full thread conversation |
 | `gws gmail send` | Send email (`--to`, `--subject`, `--body`, `--cc`, `--bcc`, `--thread-id`, `--reply-to-message-id`) |


### PR DESCRIPTION
## Summary
- Add `--all` flag to fetch all matching results via pagination
- Support `--max` values > 500 by automatically paginating
- Add progress indicator for multi-page fetches (to stderr)

## Problem
Gmail API has a hard limit of 500 results per request. Previously `gws gmail list --max 1000` would still return only 500 results.

## Solution
Implement pagination using Gmail API's `pageToken`:
- When `--all` is specified, loop until no `nextPageToken`
- When `--max > 500`, fetch multiple pages to satisfy the request
- Progress indicator shows page count and running total

## Test Plan
- [x] `gws gmail list --max 10` returns 10 (no pagination needed)
- [x] `gws gmail list --max 1000` fetches up to 1000 via pagination
- [x] `gws gmail list --all` fetches all matching results
- [x] Unit tests for pagination logic

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)