### PR TITLE
docs: update gws skills to reflect v1.10.0 features

### DIFF
--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -344,7 +344,7 @@ func TestSkillCommands_MatchCLI(t *testing.T) {
 	services := map[string]serviceCommands{
 		"gmail": {
 			parentCmd:   gmailCmd,
-			subcommands: []string{"list", "read", "send", "labels", "label", "archive", "archive-thread", "trash", "thread"},
+			subcommands: []string{"list", "read", "send", "labels", "label", "archive", "archive-thread", "trash", "thread", "reply", "event-id"},
 		},
 		"calendar": {
 			parentCmd:   calendarCmd,
@@ -374,6 +374,12 @@ func TestSkillCommands_MatchCLI(t *testing.T) {
 				"info", "list", "read", "create",
 				"add-slide", "delete-slide", "duplicate-slide",
 				"add-shape", "add-image", "add-text", "replace-text",
+				"delete-object", "delete-text",
+				"update-text-style", "update-transform",
+				"create-table", "insert-table-rows", "delete-table-row",
+				"update-table-cell", "update-table-border",
+				"update-paragraph-style", "update-shape",
+				"reorder-slides",
 			},
 		},
 		"tasks": {
@@ -542,6 +548,25 @@ func TestReferenceFiles_DocumentGlobalFlags(t *testing.T) {
 			}
 			if !strings.Contains(content, "--format") {
 				t.Error("references/commands.md missing --format global flag")
+			}
+		})
+	}
+}
+
+func TestReferenceFiles_DocumentQuietFlag(t *testing.T) {
+	base := skillsDir(t)
+	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search"}
+
+	for _, svc := range services {
+		t.Run(svc, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(base, svc, "references", "commands.md"))
+			if err != nil {
+				t.Fatalf("failed to read file: %v", err)
+			}
+			content := string(data)
+
+			if !strings.Contains(content, "--quiet") {
+				t.Error("references/commands.md missing --quiet global flag")
 			}
 		})
 	}

--- a/skills/calendar/references/commands.md
+++ b/skills/calendar/references/commands.md
@@ -10,6 +10,7 @@ Complete flag and option reference for `gws calendar` commands.
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ---
 

--- a/skills/chat/references/commands.md
+++ b/skills/chat/references/commands.md
@@ -10,6 +10,7 @@ Complete flag and option reference for `gws chat` commands.
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ## Prerequisites
 

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -177,3 +177,4 @@ gws docs read <doc-id> --format text    # Human-readable text
 - `replace` replaces ALL occurrences in the document, not just the first one
 - Document IDs can be extracted from Google Docs URLs: `docs.google.com/document/d/<ID>/edit`
 - For comments on a doc, use `gws drive comments <doc-id>`
+- Use `--quiet` on write operations to suppress JSON output in scripts

--- a/skills/docs/references/commands.md
+++ b/skills/docs/references/commands.md
@@ -10,6 +10,7 @@ Complete flag and option reference for `gws docs` commands.
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ---
 

--- a/skills/drive/references/commands.md
+++ b/skills/drive/references/commands.md
@@ -10,6 +10,7 @@ Complete flag and option reference for `gws drive` commands.
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ---
 

--- a/skills/forms/references/commands.md
+++ b/skills/forms/references/commands.md
@@ -10,6 +10,7 @@ Complete flag and option reference for `gws forms` commands.
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ---
 

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gws-gmail
-version: 1.0.0
+version: 1.1.0
 description: "Google Gmail CLI operations via gws. Use when users need to list emails, read messages, send email, manage labels, archive, or trash messages. Triggers: gmail, email, inbox, send email, mail, labels, archive, trash."
 metadata:
   short-description: Google Gmail CLI operations
@@ -33,6 +33,8 @@ For initial setup, see the `gws-auth` skill.
 | Task | Command |
 |------|---------|
 | List recent emails | `gws gmail list` |
+| List with labels | `gws gmail list --include-labels` |
+| List all matches | `gws gmail list --query "label:work" --all` |
 | List unread emails | `gws gmail list --query "is:unread"` |
 | Search emails | `gws gmail list --query "from:user@example.com"` |
 | Read a message | `gws gmail read <message-id>` |
@@ -62,8 +64,10 @@ Lists recent email threads from your inbox. Each result includes:
 - `message_count` — Number of messages in the thread
 
 **Flags:**
-- `--max int` — Maximum number of results (default 10)
+- `--max int` — Maximum number of results (default 10, use `--all` for unlimited)
+- `--all` — Fetch all matching results (may take time for large result sets)
 - `--query string` — Gmail search query (e.g., `is:unread`, `from:someone@example.com`)
+- `--include-labels` — Include Gmail label IDs in the output for each thread
 
 **Examples:**
 ```bash
@@ -71,6 +75,8 @@ gws gmail list --max 5
 gws gmail list --query "is:unread"
 gws gmail list --query "from:boss@company.com subject:urgent"
 gws gmail list --query "after:2024/01/01 has:attachment"
+gws gmail list --include-labels
+gws gmail list --query "label:work" --all
 ```
 
 ### thread — Read a full thread
@@ -212,3 +218,6 @@ gws gmail list --format text    # Human-readable text
 - Use `gws gmail archive-thread <thread-id>` to archive all messages in a conversation at once (archives + marks read)
 - To mark as read: `gws gmail label <id> --remove "UNREAD"`
 - To star a message: `gws gmail label <id> --add "STARRED"`
+- Use `--include-labels` with `list` to see which Gmail labels are applied to each thread
+- Use `--all` with `list` to fetch every matching result (bypasses the default 10 limit)
+- Use `--quiet` on any command to suppress JSON output (useful for scripted archive/label actions)

--- a/skills/gmail/references/commands.md
+++ b/skills/gmail/references/commands.md
@@ -12,6 +12,7 @@ These flags apply to all `gws gmail` commands:
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ---
 
@@ -25,8 +26,10 @@ Usage: gws gmail list [flags]
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `--max` | int | 10 | Maximum number of results |
+| `--max` | int | 10 | Maximum number of results (use `--all` for unlimited) |
+| `--all` | bool | false | Fetch all matching results (may take time for large result sets) |
 | `--query` | string | | Gmail search query |
+| `--include-labels` | bool | false | Include Gmail label IDs in output |
 
 ### Output Fields (JSON)
 
@@ -38,6 +41,7 @@ Each thread includes:
 - `from` — Original sender
 - `date` — Date of first message
 - `snippet` — Preview text
+- `labels` — Array of label IDs (only when `--include-labels` is used)
 
 ### Gmail Search Query Syntax
 

--- a/skills/search/references/commands.md
+++ b/skills/search/references/commands.md
@@ -10,6 +10,7 @@ Complete flag and option reference for `gws search` commands.
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ## Prerequisites
 

--- a/skills/sheets/SKILL.md
+++ b/skills/sheets/SKILL.md
@@ -214,3 +214,4 @@ gws sheets read <id> "A1:D10" --format text    # Human-readable text
 - `read --headers` (default true) uses the first row as JSON keys — disable with `--headers=false` for raw arrays
 - Spreadsheet IDs can be extracted from URLs: `docs.google.com/spreadsheets/d/<ID>/edit`
 - Unbounded ranges (`A:A`, `1:1`) are not supported for merge/unmerge/sort
+- Use `--quiet` on write/append/clear operations to suppress JSON output in scripts

--- a/skills/sheets/references/commands.md
+++ b/skills/sheets/references/commands.md
@@ -10,6 +10,7 @@ Complete flag and option reference for `gws sheets` commands (19 commands).
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ## Range Format Reference
 

--- a/skills/slides/SKILL.md
+++ b/skills/slides/SKILL.md
@@ -337,6 +337,7 @@ gws slides list <id> --format text    # Human-readable text
 - Positions and sizes are in **points (PT)**: standard slide is 720x405 points
 - Presentation IDs can be extracted from URLs: `docs.google.com/presentation/d/<ID>/edit`
 - For comments on a presentation, use `gws drive comments <presentation-id>`
+- Use `--quiet` on update operations to suppress JSON output in scripts
 
 ### Styling
 - Colors are always hex format with `#` prefix: `--background-color "#005843"`, `--color "#FFFFFF"`

--- a/skills/slides/references/commands.md
+++ b/skills/slides/references/commands.md
@@ -10,6 +10,7 @@ Complete flag and option reference for `gws slides` commands.
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ---
 

--- a/skills/tasks/SKILL.md
+++ b/skills/tasks/SKILL.md
@@ -133,3 +133,4 @@ gws tasks list @default --format text    # Human-readable text
 - The default task list ID is `@default` — use this when users don't specify a list
 - Due dates accept both RFC3339 (`2024-02-01T00:00:00Z`) and simple date (`2024-02-01`) formats
 - Completed tasks are hidden by default; use `--show-completed` to include them
+- Use `--quiet` on create/update/complete operations to suppress JSON output in scripts

--- a/skills/tasks/references/commands.md
+++ b/skills/tasks/references/commands.md
@@ -10,6 +10,7 @@ Complete flag and option reference for `gws tasks` commands.
 |------|------|---------|-------------|
 | `--config` | string | `~/.config/gws/config.yaml` | Config file path |
 | `--format` | string | `json` | Output format: `json` or `text` |
+| `--quiet` | bool | `false` | Suppress output (useful for scripted actions) |
 
 ---
 


### PR DESCRIPTION
## Summary
- **Gmail skill**: Document `--include-labels` flag (v1.10.0), `--all` pagination flag (v1.9.0), bump skill version to 1.1.0
- **All 10 service skills**: Add `--quiet` global flag to commands.md reference tables and SKILL.md agent tips
- **Tests**: Add `TestReferenceFiles_DocumentQuietFlag` test, fix `TestSkillCommands_MatchCLI` to include 12 missing slides commands and 2 missing gmail commands (`reply`, `event-id`)

## Changes across 16 files
| Scope | Files | What changed |
|-------|-------|-------------|
| Gmail skill | `SKILL.md`, `commands.md` | `--include-labels`, `--all`, `--quiet`, labels output field |
| Sheets/Docs/Tasks/Slides skills | 4x `SKILL.md`, 4x `commands.md` | `--quiet` flag documentation |
| Calendar/Drive/Chat/Forms/Search | 5x `commands.md` | `--quiet` in Global Flags table |
| Tests | `skills_test.go` | New quiet flag test + command list fixes |

## Test plan
- [x] `go test ./... -run "TestSkill|TestReference|TestSKILL"` — all 62 tests pass
- [x] Verified CLI help output matches skill documentation after `make build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)