### PR TITLE
feat: slides speaker notes support (v1.11.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.10.0** - Gmail label support. Adds `--include-labels` flag to `gmail list` for surfacing label IDs in thread output.
+**v1.11.0** - Slides speaker notes support. Adds `--notes` flag to `slides info`, `list`, and `read` for reading speaker notes. Extends `slides add-text` and `delete-text` with `--notes` mode to write/clear speaker notes via `--slide-id` or `--slide-number`.
 
 ## Roadmap
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.10.0
+VERSION ?= 1.11.0
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/README.md
+++ b/README.md
@@ -182,19 +182,19 @@ Add `--format text` to any command for human-readable output.
 
 | Command | Description |
 |---------|-------------|
-| `gws slides info <id>` | Presentation metadata |
-| `gws slides list <id>` | List slides with text content |
-| `gws slides read <id> [n]` | Read slide text (specific or all) |
+| `gws slides info <id>` | Presentation metadata (`--notes` for speaker notes) |
+| `gws slides list <id>` | List slides with text content (`--notes` for speaker notes) |
+| `gws slides read <id> [n]` | Read slide text (specific or all, `--notes` for speaker notes) |
 | `gws slides create` | Create new presentation (`--title`) |
 | `gws slides add-slide <id>` | Add slide (`--title`, `--body`, `--layout`) |
 | `gws slides delete-slide <id>` | Delete slide (`--slide-id` or `--slide-number`) |
 | `gws slides duplicate-slide <id>` | Duplicate slide (`--slide-id` or `--slide-number`) |
 | `gws slides add-shape <id>` | Add shape (`--slide-id/--slide-number`, `--type`, `--x`, `--y`, `--width`, `--height`) |
 | `gws slides add-image <id>` | Add image (`--slide-id/--slide-number`, `--url`, `--x`, `--y`, `--width`) |
-| `gws slides add-text <id>` | Insert text into shape or table cell (`--object-id` or `--table-id`/`--row`/`--col`, `--text`, `--at`) |
+| `gws slides add-text <id>` | Insert text into shape, table cell, or speaker notes (`--object-id`, `--table-id`/`--row`/`--col`, or `--notes`/`--slide-number`) |
 | `gws slides replace-text <id>` | Find and replace text (`--find`, `--replace`, `--match-case`) |
 | `gws slides delete-object <id>` | Delete any page element (`--object-id`) |
-| `gws slides delete-text <id>` | Clear text from shape (`--object-id`, `--from`, `--to`) |
+| `gws slides delete-text <id>` | Clear text from shape or speaker notes (`--object-id` or `--notes`/`--slide-number`) |
 | `gws slides update-text-style <id>` | Style text (`--object-id`, `--bold`, `--italic`, `--font-size`, `--color`) |
 | `gws slides update-transform <id>` | Move/scale/rotate element (`--object-id`, `--x`, `--y`, `--scale-x`, `--rotate`) |
 | `gws slides create-table <id>` | Add table (`--slide-id/--slide-number`, `--rows`, `--cols`) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,10 @@ Feature roadmap for the Google Workspace CLI. Items are organized by priority an
 
 ## Completed
 
+### v1.11.0
+- [x] Slides: `--notes` flag on `info`, `list`, `read` to include speaker notes in output
+- [x] Slides: `--notes` mode on `add-text` and `delete-text` to write/clear speaker notes (with `--slide-id` or `--slide-number`)
+
 ### v0.7.0
 - [x] `gws drive create-folder` - Create folder
 - [x] `gws drive move` - Move file to folder

--- a/skills/slides/SKILL.md
+++ b/skills/slides/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gws-slides
-version: 1.3.0
+version: 1.4.0
 description: "Google Slides CLI operations via gws. Use when users need to create, read, or edit Google Slides presentations. Triggers: slides, presentation, google slides, deck."
 metadata:
   short-description: Google Slides CLI operations
@@ -36,6 +36,7 @@ For initial setup, see the `gws-auth` skill.
 | List all slides | `gws slides list <id>` |
 | Read slide content | `gws slides read <id>` |
 | Read specific slide | `gws slides read <id> 3` |
+| Read with speaker notes | `gws slides read <id> --notes` |
 | Create presentation | `gws slides create --title "My Deck"` |
 | Add a slide | `gws slides add-slide <id> --title "Slide Title" --body "Content"` |
 | Add blank slide | `gws slides add-slide <id> --layout BLANK` |
@@ -45,6 +46,8 @@ For initial setup, see the `gws-auth` skill.
 | Add an image | `gws slides add-image <id> --slide-number 1 --url "https://..."` |
 | Add text to shape | `gws slides add-text <id> --object-id <obj-id> --text "Hello"` |
 | Add text to table cell | `gws slides add-text <id> --table-id <tbl-id> --row 0 --col 0 --text "Cell"` |
+| Add speaker notes | `gws slides add-text <id> --notes --slide-number 1 --text "Notes here"` |
+| Clear speaker notes | `gws slides delete-text <id> --notes --slide-number 1` |
 | Find and replace | `gws slides replace-text <id> --find "old" --replace "new"` |
 | Delete any element | `gws slides delete-object <id> --object-id <obj-id>` |
 | Clear text from shape | `gws slides delete-text <id> --object-id <obj-id>` |
@@ -64,24 +67,33 @@ For initial setup, see the `gws-auth` skill.
 ### info — Get presentation info
 
 ```bash
-gws slides info <presentation-id>
+gws slides info <presentation-id> [--notes]
 ```
+
+**Flags:**
+- `--notes` — Include speaker notes in output
 
 ### list — List all slides
 
 ```bash
-gws slides list <presentation-id>
+gws slides list <presentation-id> [--notes]
 ```
 
 Lists all slides with their content and object IDs.
 
+**Flags:**
+- `--notes` — Include speaker notes in output
+
 ### read — Read slide content
 
 ```bash
-gws slides read <presentation-id> [slide-number]
+gws slides read <presentation-id> [slide-number] [--notes]
 ```
 
 Reads text content. Omit slide number to read all slides. Slide numbers are **1-indexed**.
+
+**Flags:**
+- `--notes` — Include speaker notes in output
 
 ### create — Create a presentation
 
@@ -153,7 +165,7 @@ gws slides add-image <presentation-id> --url <image-url> [flags]
 - `--y float` — Y position in points (default: 100)
 - `--width float` — Width in points (default: 400; height auto-calculated)
 
-### add-text — Add text to shape or table cell
+### add-text — Add text to shape, table cell, or speaker notes
 
 ```bash
 # For shapes/text boxes:
@@ -161,13 +173,19 @@ gws slides add-text <presentation-id> --object-id <id> --text <text> [flags]
 
 # For table cells:
 gws slides add-text <presentation-id> --table-id <id> --row <n> --col <n> --text <text> [flags]
+
+# For speaker notes:
+gws slides add-text <presentation-id> --notes --slide-number <n> --text <text> [flags]
 ```
 
 **Flags:**
-- `--object-id string` — Shape/text box ID (mutually exclusive with --table-id)
+- `--object-id string` — Shape/text box ID (mutually exclusive with --table-id and --notes)
 - `--table-id string` — Table object ID (requires --row and --col)
 - `--row int` — Row index, 0-based (required with --table-id)
 - `--col int` — Column index, 0-based (required with --table-id)
+- `--notes` — Target speaker notes shape (mutually exclusive with --object-id and --table-id)
+- `--slide-id string` — Slide object ID (required with --notes)
+- `--slide-number int` — Slide number, 1-indexed (required with --notes)
 - `--text string` — Text to insert (required)
 - `--at int` — Position to insert at (0 = beginning)
 
@@ -194,14 +212,18 @@ gws slides delete-object <presentation-id> --object-id <id>
 
 Deletes shapes, images, tables, or any page element by object ID.
 
-### delete-text — Clear text from shape
+### delete-text — Clear text from shape or speaker notes
 
 ```bash
 gws slides delete-text <presentation-id> --object-id <id> [flags]
+gws slides delete-text <presentation-id> --notes --slide-number <n> [flags]
 ```
 
 **Flags:**
-- `--object-id string` — Shape containing text (required)
+- `--object-id string` — Shape containing text (required unless --notes)
+- `--notes` — Target speaker notes shape (alternative to --object-id)
+- `--slide-id string` — Slide object ID (required with --notes)
+- `--slide-number int` — Slide number, 1-indexed (required with --notes)
 - `--from int` — Start index (default: 0)
 - `--to int` — End index (if omitted, deletes to end)
 

--- a/skills/slides/references/commands.md
+++ b/skills/slides/references/commands.md
@@ -19,8 +19,12 @@ Complete flag and option reference for `gws slides` commands.
 Gets metadata about a Google Slides presentation.
 
 ```
-Usage: gws slides info <presentation-id>
+Usage: gws slides info <presentation-id> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--notes` | bool | `false` | Include speaker notes in output |
 
 ---
 
@@ -29,8 +33,12 @@ Usage: gws slides info <presentation-id>
 Lists all slides in a presentation with their content and object IDs.
 
 ```
-Usage: gws slides list <presentation-id>
+Usage: gws slides list <presentation-id> [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--notes` | bool | `false` | Include speaker notes in output |
 
 Returns slide details including object IDs for elements — needed for `add-text`.
 
@@ -41,8 +49,12 @@ Returns slide details including object IDs for elements — needed for `add-text
 Reads the text content of a specific slide or all slides.
 
 ```
-Usage: gws slides read <presentation-id> [slide-number]
+Usage: gws slides read <presentation-id> [slide-number] [flags]
 ```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--notes` | bool | `false` | Include speaker notes in output |
 
 Slide numbers are **1-indexed**. Omit the slide number to read all slides.
 
@@ -178,7 +190,7 @@ Height is automatically calculated to maintain aspect ratio based on width.
 
 ## gws slides add-text
 
-Inserts text into an existing shape or text box.
+Inserts text into an existing shape, text box, table cell, or speaker notes.
 
 ```
 Usage: gws slides add-text <presentation-id> [flags]
@@ -186,11 +198,17 @@ Usage: gws slides add-text <presentation-id> [flags]
 
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
-| `--object-id` | string | | Yes | Object ID to insert text into |
+| `--object-id` | string | | | Object ID to insert text into (mutually exclusive with --table-id and --notes) |
+| `--table-id` | string | | | Table object ID (requires --row and --col) |
+| `--row` | int | -1 | | Row index, 0-based (required with --table-id) |
+| `--col` | int | -1 | | Column index, 0-based (required with --table-id) |
+| `--notes` | bool | false | | Target speaker notes (mutually exclusive with --object-id and --table-id) |
+| `--slide-id` | string | | | Slide object ID (required with --notes) |
+| `--slide-number` | int | 0 | | Slide number, 1-indexed (required with --notes) |
 | `--text` | string | | Yes | Text to insert |
 | `--at` | int | 0 | No | Position to insert at (0 = beginning) |
 
-Get object IDs from `gws slides list <id>` output.
+One of `--object-id`, `--table-id`, or `--notes` is required. Get object IDs from `gws slides list <id>` output.
 
 ---
 
@@ -230,7 +248,7 @@ Get object IDs from `gws slides list <id>` output.
 
 ## gws slides delete-text
 
-Clears text from a shape, optionally within a specific range.
+Clears text from a shape or speaker notes, optionally within a specific range.
 
 ```
 Usage: gws slides delete-text <presentation-id> [flags]
@@ -238,9 +256,14 @@ Usage: gws slides delete-text <presentation-id> [flags]
 
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
-| `--object-id` | string | | Yes | Shape containing text |
+| `--object-id` | string | | | Shape containing text (required unless --notes) |
+| `--notes` | bool | false | | Target speaker notes (alternative to --object-id) |
+| `--slide-id` | string | | | Slide object ID (required with --notes) |
+| `--slide-number` | int | 0 | | Slide number, 1-indexed (required with --notes) |
 | `--from` | int | 0 | No | Start index |
 | `--to` | int | | No | End index (if omitted, deletes to end) |
+
+One of `--object-id` or `--notes` is required.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `--notes` flag to `slides info`, `list`, and `read` commands to include speaker notes in JSON output
- Add `--notes` mode to `slides add-text` and `delete-text` for writing/clearing speaker notes (with `--slide-id` or `--slide-number`)
- No extra API calls needed — `Presentations.Get()` already returns notes data
- Version bump to v1.11.0 (CLI) and v1.4.0 (slides skill)

## Test plan
- [x] `go test ./cmd/...` — all existing + 10 new tests pass
- [x] `make build` — binary shows v1.11.0
- [ ] Manual: `gws slides read <id> --notes` returns notes in output
- [ ] Manual: `gws slides add-text <id> --notes --slide-number 1 --text "test"` writes notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)