### PR TITLE
feat: add YAML output format (v1.13.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.12.0** - Add golangci-lint for comprehensive static analysis, fix lint findings across codebase, add test coverage for chat/forms/search commands.
+**v1.13.0** - Add YAML output format (`--format yaml`) alongside existing JSON and text formats.
 
 ## Roadmap
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.12.0
+VERSION ?= 1.13.0
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
   <a href="go.mod"><img src="https://img.shields.io/badge/Go-1.23+-00ADD8.svg" alt="Go Version"></a>
 </p>
 
-`gws` gives developers and AI agents a structured, token-efficient interface to 10+ Google Workspace services. Every command returns consistent JSON (or human-readable text), making it ideal for scripting, automation, and agent toolchains.
+`gws` gives developers and AI agents a structured, token-efficient interface to 10+ Google Workspace services. Every command returns consistent JSON (or YAML or human-readable text), making it ideal for scripting, automation, and agent toolchains.
 
 **Built for AI & automation:** Drop `gws` into Claude Code, Codex, or shell scripts and they inherit structured output, predictable flags, and safe defaults — no wrapper code required.
 
 ## Features
 
 - **10+ Google services** — Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, Chat, Forms, Custom Search.
-- **Scriptable output** — `--format json` (default), `--format text` for human-readable tables, or `--quiet` to suppress output.
+- **Scriptable output** — `--format json` (default), `--format yaml`, `--format text` for human-readable tables, or `--quiet` to suppress output.
 - **OAuth2 + PKCE** — Secure browser-based auth with automatic token refresh and `0600` file permissions.
 - **Single auth flow** — Authenticate once to access all services; all scopes requested upfront.
 - **Lazy clients** — Service clients are initialized on-demand with mutex protection.
@@ -78,7 +78,7 @@ gws sheets read <spreadsheet-id> "Sheet1!A1:D10"
 gws tasks lists
 ```
 
-Add `--format text` to any command for human-readable output.
+Add `--format text` for human-readable output, or `--format yaml` for YAML.
 
 ## Commands
 
@@ -258,7 +258,7 @@ internal/
   auth/           # OAuth2 + PKCE flow, token management
   client/         # Lazy-initialized Google API service factory
   config/         # Viper configuration and path resolution
-  printer/        # JSON and text output formatters
+  printer/        # JSON, YAML, and text output formatters
 main.go           # Entry point
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,9 @@ Feature roadmap for the Google Workspace CLI. Items are organized by priority an
 
 ## Completed
 
+### v1.13.0
+- [x] Add YAML output format (`--format yaml`) alongside existing JSON and text
+
 ### v1.12.0
 - [x] Add golangci-lint with `.golangci.yml` config (replaces basic `go vet` in CI and Makefile)
 - [x] Fix lint findings across codebase (unchecked errors, unused consts, gofmt, staticcheck)
@@ -304,14 +307,6 @@ gws apps-script run <script-id> --function "myFunction"
 ## CLI Infrastructure (Competitive Gaps)
 
 Identified from comparison with [jenkins-cli](https://github.com/avivsinai/jenkins-cli) and [bitbucket-cli](https://github.com/avivsinai/bitbucket-cli).
-
-### Add YAML output format (P1, M)
-
-Add `--format yaml` alongside existing JSON and text. Both `jk` and `bkt` support YAML output.
-
-```bash
-gws gmail list --max 5 --format yaml
-```
 
 ### OS keychain token storage (P2, M)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,7 +33,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is ~/.config/gws/config.yaml)")
-	rootCmd.PersistentFlags().StringVar(&format, "format", "json", "output format: json or text")
+	rootCmd.PersistentFlags().StringVar(&format, "format", "json", "output format: json, text, or yaml")
 	rootCmd.PersistentFlags().BoolVar(&quiet, "quiet", false, "suppress output (useful for scripted actions)")
 
 	viper.BindPFlag("format", rootCmd.PersistentFlags().Lookup("format"))

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	golang.org/x/oauth2 v0.25.0
 	google.golang.org/api v0.214.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -48,5 +49,4 @@ require (
 	google.golang.org/grpc v1.67.1 // indirect
 	google.golang.org/protobuf v1.35.2 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -15,6 +15,8 @@ func New(w io.Writer, format string) Printer {
 	switch format {
 	case "text":
 		return NewTextPrinter(w)
+	case "yaml":
+		return NewYAMLPrinter(w)
 	default:
 		return NewJSONPrinter(w)
 	}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -114,6 +114,101 @@ func TestNullPrinter_HandlesLargeData(t *testing.T) {
 	}
 }
 
+func TestNew_YAML(t *testing.T) {
+	var buf bytes.Buffer
+	p := New(&buf, "yaml")
+
+	if _, ok := p.(*YAMLPrinter); !ok {
+		t.Error("expected YAMLPrinter for 'yaml' format")
+	}
+}
+
+func TestYAMLPrinter_Print_Map(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewYAMLPrinter(&buf)
+
+	data := map[string]interface{}{
+		"name":  "test",
+		"count": 42,
+	}
+
+	if err := p.Print(data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "name: test") {
+		t.Errorf("expected 'name: test' in output: %s", output)
+	}
+	if !strings.Contains(output, "count: 42") {
+		t.Errorf("expected 'count: 42' in output: %s", output)
+	}
+}
+
+func TestYAMLPrinter_Print_Slice(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewYAMLPrinter(&buf)
+
+	data := []string{"a", "b", "c"}
+
+	if err := p.Print(data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "- a") {
+		t.Errorf("expected '- a' in output: %s", output)
+	}
+	if !strings.Contains(output, "- b") {
+		t.Errorf("expected '- b' in output: %s", output)
+	}
+}
+
+func TestYAMLPrinter_Print_Nested(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewYAMLPrinter(&buf)
+
+	data := map[string]interface{}{
+		"user": map[string]interface{}{
+			"name":  "John",
+			"email": "john@example.com",
+		},
+		"items": []int{1, 2, 3},
+	}
+
+	if err := p.Print(data); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "name: John") {
+		t.Errorf("expected nested name in output: %s", output)
+	}
+	if !strings.Contains(output, "email: john@example.com") {
+		t.Errorf("expected nested email in output: %s", output)
+	}
+}
+
+func TestYAMLPrinter_PrintError(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewYAMLPrinter(&buf)
+
+	err := errors.New("something went wrong")
+	if printErr := p.PrintError(err); printErr != nil {
+		t.Fatalf("unexpected error: %v", printErr)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "error: something went wrong") {
+		t.Errorf("expected error message in output: %s", output)
+	}
+}
+
+func TestYAMLPrinter_ImplementsPrinter(t *testing.T) {
+	var p Printer = NewYAMLPrinter(&bytes.Buffer{})
+	_ = p // Verify interface compliance
+}
+
 func TestNew_UnknownFormat(t *testing.T) {
 	var buf bytes.Buffer
 	p := New(&buf, "xml")

--- a/internal/printer/yaml.go
+++ b/internal/printer/yaml.go
@@ -1,0 +1,31 @@
+package printer
+
+import (
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// YAMLPrinter outputs data as YAML.
+type YAMLPrinter struct {
+	w io.Writer
+}
+
+// NewYAMLPrinter creates a new YAML printer.
+func NewYAMLPrinter(w io.Writer) *YAMLPrinter {
+	return &YAMLPrinter{w: w}
+}
+
+// Print outputs data as YAML.
+func (p *YAMLPrinter) Print(data interface{}) error {
+	enc := yaml.NewEncoder(p.w)
+	enc.SetIndent(2)
+	return enc.Encode(data)
+}
+
+// PrintError outputs an error as YAML.
+func (p *YAMLPrinter) PrintError(err error) error {
+	return p.Print(map[string]interface{}{
+		"error": err.Error(),
+	})
+}


### PR DESCRIPTION
## Summary
- Add `--format yaml` output option alongside existing JSON and text formats
- New `YAMLPrinter` in `internal/printer/yaml.go` using `gopkg.in/yaml.v3` with 2-space indent
- 6 new tests covering factory, map/slice/nested output, error wrapping, and interface compliance
- Updated README, CLAUDE.md, ROADMAP.md, and Makefile for v1.13.0

## Test plan
- [x] `golangci-lint run ./...` passes clean
- [x] `go test ./...` — all tests pass (6 new YAML tests)
- [x] `gws version` shows 1.13.0
- [ ] `gws gmail list --max 1 --format yaml` produces valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)