### PR TITLE
feat: add Docs formatting & lists, bump to v1.14.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,10 +22,11 @@
 | `calendar` | list, events, create, update, delete, rsvp |
 | `tasks` | lists, list, create, complete |
 | `drive` | list, search, info, download, upload, create-folder, move, delete, comments |
-| `docs` | read, info, create, append, insert, replace, delete, add-table |
-| `sheets` | info, list, read, create, write, append, add-sheet, delete-sheet, clear, insert-rows, delete-rows, insert-cols, delete-cols, rename-sheet, duplicate-sheet, merge, unmerge, sort, find-replace |
+| `docs` | read, info, create, append, insert, replace, delete, add-table, format, set-paragraph-style, add-list, remove-list |
+| `sheets` | info, list, read, create, write, append, add-sheet, delete-sheet, clear, insert-rows, delete-rows, insert-cols, delete-cols, rename-sheet, duplicate-sheet, merge, unmerge, sort, find-replace, format, set-column-width, set-row-height, freeze |
 | `slides` | info, list, read, create, add-slide, delete-slide, duplicate-slide, add-shape, add-image, add-text, replace-text, delete-object, delete-text, update-text-style, update-transform, create-table, insert-table-rows, delete-table-row, update-table-cell, update-table-border, update-paragraph-style, update-shape, reorder-slides |
 | `chat` | list, messages, send (needs Chat App config) |
+| `contacts` | list, search, get, create, delete |
 | `forms` | info, responses |
 | `search` | web search (needs API key) |
 | `version` | Show version info |
@@ -45,7 +46,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.13.0** - Add YAML output format (`--format yaml`) alongside existing JSON and text formats.
+**v1.14.0** - Add Contacts (People API), Sheets formatting, and Docs formatting & lists.
 
 ## Roadmap
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.13.0
+VERSION ?= 1.14.0
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ Add `--format text` for human-readable output, or `--format yaml` for YAML.
 | `gws docs replace <id>` | Find and replace text (`--find`, `--replace`, `--match-case`) |
 | `gws docs delete <id>` | Delete content range (`--from`, `--to`) |
 | `gws docs add-table <id>` | Insert table (`--rows`, `--cols`, `--at`) |
+| `gws docs format <id>` | Format text (`--from`, `--to`, `--bold`, `--italic`, `--font-size`, `--color`) |
+| `gws docs set-paragraph-style <id>` | Paragraph style (`--from`, `--to`, `--alignment`, `--line-spacing`) |
+| `gws docs add-list <id>` | Add bullet/numbered list (`--at`, `--type`, `--items`) |
+| `gws docs remove-list <id>` | Remove list formatting (`--from`, `--to`) |
 
 ### Sheets
 
@@ -177,6 +181,10 @@ Add `--format text` for human-readable output, or `--format yaml` for YAML.
 | `gws sheets unmerge <id> <range>` | Unmerge cells |
 | `gws sheets sort <id> <range>` | Sort data (`--by`, `--desc`, `--has-header`) |
 | `gws sheets find-replace <id>` | Find and replace (`--find`, `--replace`, `--sheet`, `--match-case`) |
+| `gws sheets format <id> <range>` | Format cells (`--bold`, `--italic`, `--bg-color`, `--color`, `--font-size`) |
+| `gws sheets set-column-width <id>` | Set column width (`--sheet`, `--col`, `--width`) |
+| `gws sheets set-row-height <id>` | Set row height (`--sheet`, `--row`, `--height`) |
+| `gws sheets freeze <id>` | Freeze panes (`--sheet`, `--rows`, `--cols`) |
 
 ### Slides
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,11 @@ Feature roadmap for the Google Workspace CLI. Items are organized by priority an
 
 ## Completed
 
+### v1.14.0
+- [x] Contacts / People API: list, search, get, create, delete
+- [x] Sheets Formatting: format cells, set-column-width, set-row-height, freeze panes
+- [x] Docs Formatting & Lists: format text, set-paragraph-style, add-list, remove-list
+
 ### v1.13.0
 - [x] Add YAML output format (`--format yaml`) alongside existing JSON and text
 
@@ -48,24 +53,6 @@ Feature roadmap for the Google Workspace CLI. Items are organized by priority an
 ---
 
 ## Planned Features
-
-### Sheets Formatting (P2, M)
-
-Cell and range formatting capabilities.
-
-```bash
-gws sheets format <id> <range> --bold --italic --bg-color "#FFFF00"
-# API: batchUpdate → repeatCell with CellFormat
-
-gws sheets set-column-width <id> --sheet "Sheet1" --col A --width 200
-# API: batchUpdate → updateDimensionProperties
-
-gws sheets set-row-height <id> --sheet "Sheet1" --row 1 --height 50
-# API: batchUpdate → updateDimensionProperties
-
-gws sheets freeze <id> --sheet "Sheet1" --rows 1 --cols 1
-# API: batchUpdate → updateSheetProperties (gridProperties.frozenRowCount/frozenColumnCount)
-```
 
 ### Sheets Charts (P2, C)
 
@@ -126,30 +113,6 @@ gws sheets list-conditional-formats <id> --sheet "Sheet1"
 
 gws sheets delete-conditional-format <id> --index 0 --sheet "Sheet1"
 # API: batchUpdate → deleteConditionalFormatRule
-```
-
-### Docs Formatting (P2, M)
-
-Text formatting in documents.
-
-```bash
-gws docs format <id> --from 10 --to 50 --bold --italic --font-size 14
-# API: batchUpdate → updateTextStyle
-
-gws docs set-paragraph-style <id> --from 10 --to 100 --alignment CENTER --line-spacing 1.5
-# API: batchUpdate → updateParagraphStyle
-```
-
-### Docs Lists (P2, M)
-
-Create and manage lists.
-
-```bash
-gws docs add-list <id> --at 10 --type bullet --items "Item1;Item2;Item3"
-# API: batchUpdate → insertText + createParagraphBullets
-
-gws docs remove-list <id> --from 10 --to 50
-# API: batchUpdate → deleteParagraphBullets
 ```
 
 ### Slides Advanced (P2, M)
@@ -223,27 +186,6 @@ gws tasks move <list-id> <task-id> --parent <parent-task-id>
 ## New Services (Competitive Gaps — gogcli)
 
 Identified from comparison with [gogcli](https://github.com/steipete/gogcli).
-
-### Contacts / People API (P2, M)
-
-Search and manage Google Contacts via the People API.
-
-```bash
-gws contacts list --max 50
-# API: people.connections.list
-
-gws contacts search "John"
-# API: people.searchContacts
-
-gws contacts create --name "John Doe" --email john@example.com --phone "+1234567890"
-# API: people.createContact
-
-gws contacts get <resource-name>
-# API: people.get
-
-gws contacts delete <resource-name>
-# API: people.deleteContact
-```
 
 ### Groups (P3, S) — Workspace only
 

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -292,6 +292,10 @@ func TestDocsCommands(t *testing.T) {
 		{"append"},
 		{"insert"},
 		{"replace"},
+		{"format"},
+		{"set-paragraph-style"},
+		{"add-list"},
+		{"remove-list"},
 	}
 
 	for _, tt := range tests {

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -43,6 +43,10 @@ For initial setup, see the `gws-auth` skill.
 | Find and replace | `gws docs replace <doc-id> --find "old" --replace "new"` |
 | Delete content | `gws docs delete <doc-id> --from 5 --to 10` |
 | Add a table | `gws docs add-table <doc-id> --rows 3 --cols 4` |
+| Format text | `gws docs format <doc-id> --from 1 --to 10 --bold` |
+| Set paragraph style | `gws docs set-paragraph-style <doc-id> --from 1 --to 100 --alignment CENTER` |
+| Add a list | `gws docs add-list <doc-id> --at 1 --type bullet --items "A;B;C"` |
+| Remove list | `gws docs remove-list <doc-id> --from 1 --to 50` |
 
 ## Detailed Usage
 
@@ -140,6 +144,53 @@ gws docs add-table <document-id> [flags]
 - `--rows int` — Number of rows (default: 3)
 - `--cols int` — Number of columns (default: 3)
 - `--at int` — Position to insert at (1-based index, default: 1)
+
+### format — Format text style
+
+```bash
+gws docs format <document-id> [flags]
+```
+
+**Flags:**
+- `--from int` — Start position (1-based index, required)
+- `--to int` — End position (1-based index, required)
+- `--bold` — Make text bold
+- `--italic` — Make text italic
+- `--font-size int` — Font size in points
+- `--color string` — Text color (hex, e.g., "#FF0000")
+
+### set-paragraph-style — Set paragraph style
+
+```bash
+gws docs set-paragraph-style <document-id> [flags]
+```
+
+**Flags:**
+- `--from int` — Start position (1-based index, required)
+- `--to int` — End position (1-based index, required)
+- `--alignment string` — Paragraph alignment: START, CENTER, END, JUSTIFIED
+- `--line-spacing float` — Line spacing multiplier (e.g., 1.15, 1.5, 2.0)
+
+### add-list — Add a bullet or numbered list
+
+```bash
+gws docs add-list <document-id> [flags]
+```
+
+**Flags:**
+- `--at int` — Position to insert at (1-based index, default: 1)
+- `--type string` — List type: bullet or numbered (default: bullet)
+- `--items string` — List items separated by semicolons (required)
+
+### remove-list — Remove list formatting
+
+```bash
+gws docs remove-list <document-id> [flags]
+```
+
+**Flags:**
+- `--from int` — Start position (1-based index, required)
+- `--to int` — End position (1-based index, required)
 
 ## Content Formats
 

--- a/skills/docs/references/commands.md
+++ b/skills/docs/references/commands.md
@@ -157,6 +157,77 @@ Use `gws docs read <id> --include-formatting` to determine correct positions.
 
 ---
 
+## gws docs format
+
+Applies text formatting to a range of positions in the document.
+
+```
+Usage: gws docs format <document-id> [flags]
+```
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--from` | int | | Yes | Start position (1-based index) |
+| `--to` | int | | Yes | End position (1-based index) |
+| `--bold` | bool | false | No | Make text bold |
+| `--italic` | bool | false | No | Make text italic |
+| `--font-size` | int | 0 | No | Font size in points |
+| `--color` | string | | No | Text color (hex, e.g., `#FF0000`) |
+
+At least one formatting flag is required.
+
+---
+
+## gws docs set-paragraph-style
+
+Sets paragraph style properties for a range of positions.
+
+```
+Usage: gws docs set-paragraph-style <document-id> [flags]
+```
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--from` | int | | Yes | Start position (1-based index) |
+| `--to` | int | | Yes | End position (1-based index) |
+| `--alignment` | string | | No | Paragraph alignment: `START`, `CENTER`, `END`, `JUSTIFIED` |
+| `--line-spacing` | float | 0 | No | Line spacing multiplier (e.g., 1.15, 1.5, 2.0) |
+
+At least one of `--alignment` or `--line-spacing` is required.
+
+---
+
+## gws docs add-list
+
+Inserts text items as a bullet or numbered list at a specified position.
+
+```
+Usage: gws docs add-list <document-id> [flags]
+```
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--at` | int | 1 | No | Position to insert at (1-based index) |
+| `--type` | string | `bullet` | No | List type: `bullet` or `numbered` |
+| `--items` | string | | Yes | List items separated by semicolons |
+
+---
+
+## gws docs remove-list
+
+Removes bullet or numbered list formatting from a range.
+
+```
+Usage: gws docs remove-list <document-id> [flags]
+```
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--from` | int | | Yes | Start position (1-based index) |
+| `--to` | int | | Yes | End position (1-based index) |
+
+---
+
 ## Content Formats
 
 The `--content-format` flag is available on `create`, `append`, and `insert` commands.


### PR DESCRIPTION
## Summary
- Add `format` command: UpdateTextStyle for bold/italic/font-size/color
- Add `set-paragraph-style` command: UpdateParagraphStyle for alignment/line-spacing
- Add `add-list` command: InsertText + CreateParagraphBullets for bullet/numbered lists
- Add `remove-list` command: DeleteParagraphBullets to remove list formatting
- Version bump to v1.14.0 (Makefile, CLAUDE.md, ROADMAP.md, README.md)

## Test plan
- [x] All existing tests pass
- [x] golangci-lint clean
- [x] New flag tests + mock server tests for all 4 commands
- [x] parseDocsHexColor helper tests
- [x] Skill docs updated
- [x] README.md updated with contacts + sheets/docs formatting commands
- [ ] Manual: `gws docs format --help`, `gws docs add-list --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)