### PR TITLE
fix: add contacts skill to test expectations

### DIFF
--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -128,6 +128,7 @@ func TestMarketplaceJSON_Valid(t *testing.T) {
 var expectedSkills = []string{
 	"gmail", "calendar", "drive", "docs", "sheets",
 	"slides", "tasks", "chat", "forms", "search", "auth",
+	"contacts",
 }
 
 func TestSkillDirectories_AllExist(t *testing.T) {
@@ -162,6 +163,7 @@ func TestSkillFiles_AllHaveReferences(t *testing.T) {
 	servicesWithCommands := []string{
 		"gmail", "calendar", "drive", "docs", "sheets",
 		"slides", "tasks", "chat", "forms", "search",
+		"contacts",
 	}
 	for _, skill := range servicesWithCommands {
 		path := filepath.Join(base, skill, "references", "commands.md")
@@ -280,7 +282,7 @@ func TestSKILLmd_HasDependencyCheck(t *testing.T) {
 func TestSKILLmd_HasAuthSection(t *testing.T) {
 	base := skillsDir(t)
 	// All service skills (not auth itself) should reference authentication
-	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms"}
+	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "contacts"}
 	for _, skill := range services {
 		t.Run(skill, func(t *testing.T) {
 			data, err := os.ReadFile(filepath.Join(base, skill, "SKILL.md"))
@@ -299,7 +301,7 @@ func TestSKILLmd_HasAuthSection(t *testing.T) {
 func TestSKILLmd_HasOutputModes(t *testing.T) {
 	base := skillsDir(t)
 	// All service skills should document output modes
-	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search"}
+	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search", "contacts"}
 	for _, skill := range services {
 		t.Run(skill, func(t *testing.T) {
 			data, err := os.ReadFile(filepath.Join(base, skill, "SKILL.md"))
@@ -393,6 +395,10 @@ func TestSkillCommands_MatchCLI(t *testing.T) {
 		"forms": {
 			parentCmd:   formsCmd,
 			subcommands: []string{"info", "responses"},
+		},
+		"contacts": {
+			parentCmd:   contactsCmd,
+			subcommands: []string{"list", "search", "get", "create", "delete"},
 		},
 	}
 
@@ -506,7 +512,7 @@ func TestReferenceFiles_HaveDisclaimer(t *testing.T) {
 	base := skillsDir(t)
 
 	// commands.md files
-	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search"}
+	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search", "contacts"}
 	for _, svc := range services {
 		t.Run(svc+"/commands.md", func(t *testing.T) {
 			data, err := os.ReadFile(filepath.Join(base, svc, "references", "commands.md"))
@@ -533,7 +539,7 @@ func TestReferenceFiles_HaveDisclaimer(t *testing.T) {
 
 func TestReferenceFiles_DocumentGlobalFlags(t *testing.T) {
 	base := skillsDir(t)
-	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search"}
+	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search", "contacts"}
 
 	for _, svc := range services {
 		t.Run(svc, func(t *testing.T) {
@@ -555,7 +561,7 @@ func TestReferenceFiles_DocumentGlobalFlags(t *testing.T) {
 
 func TestReferenceFiles_DocumentQuietFlag(t *testing.T) {
 	base := skillsDir(t)
-	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search"}
+	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search", "contacts"}
 
 	for _, svc := range services {
 		t.Run(svc, func(t *testing.T) {
@@ -593,7 +599,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 	}
 
 	// references/commands.md files
-	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search"}
+	services := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "search", "contacts"}
 	for _, svc := range services {
 		if _, err := os.Stat(filepath.Join(base, svc, "references", "commands.md")); err == nil {
 			count++
@@ -605,7 +611,7 @@ func TestSkillFiles_TotalCount(t *testing.T) {
 		count++
 	}
 
-	expectedTotal := 23 // 1 marketplace.json + 11 SKILL.md + 10 commands.md + 1 setup-guide.md
+	expectedTotal := 25 // 1 marketplace.json + 12 SKILL.md + 11 commands.md + 1 setup-guide.md
 	if count != expectedTotal {
 		t.Errorf("expected %d skill files, found %d", expectedTotal, count)
 	}


### PR DESCRIPTION
## Summary
- Adds `contacts` to `expectedSkills` and all service lists in `skills_test.go`
- Updates expected file count from 23 to 25 (12 SKILL.md + 11 commands.md)
- Adds contacts CLI commands to the cross-reference test

Fixes CI failure introduced in 801dd1f where the contacts skill was registered in the plugin manifest but the tests weren't updated.

## Test plan
- [x] `go test ./...` passes locally
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)