### PR TITLE
feat(calendar): expand events output to include all common fields (v1.17.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.16.0
+VERSION ?= 1.17.0
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - **10+ Google services** — Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, Chat, Forms, Contacts, Custom Search.
 - **Scriptable output** — `--format json` (default), `--format yaml`, `--format text` for human-readable tables, or `--quiet` to suppress output.
 - **OAuth2 + PKCE** — Secure browser-based auth with automatic token refresh and `0600` file permissions.
-- **Single auth flow** — Authenticate once to access all services; all scopes requested upfront.
+- **Single auth flow** — Authenticate once to access all services; scopes based on `--services` flag, config, or all by default.
 - **Lazy clients** — Service clients are initialized on-demand with mutex protection.
 
 ## Installation
@@ -111,7 +111,7 @@ Add `--format text` for human-readable output, or `--format yaml` for YAML.
 | Command | Description |
 |---------|-------------|
 | `gws calendar list` | List all calendars |
-| `gws calendar events` | List upcoming events (`--days`, `--calendar-id`, `--max`) |
+| `gws calendar events` | List upcoming events with expanded details (`--days`, `--calendar-id`, `--max`, `--pending`) |
 | `gws calendar create` | Create event (`--title`, `--start`, `--end`, `--attendees`) |
 | `gws calendar update <id>` | Update event (`--title`, `--start`, `--end`, `--add-attendees`) |
 | `gws calendar delete <id>` | Delete event |

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,24 @@
 # Releases
 
+## v1.17.0
+
+**Full Calendar Event Fields**
+
+### Calendar
+- `gws calendar events` now returns expanded Google Calendar API fields
+  - New fields: `description`, `html_link`, `created`, `updated`, `color_id`, `visibility`, `transparency`, `event_type`, `creator`
+  - Full `attendees[]` list with `email`, `response_status`, `optional`, `organizer`, `self`
+  - `conference` data with `conference_id`, `solution`, `entry_points[]`
+  - `attachments[]` with `file_url`, `title`, `mime_type`, `file_id`
+  - `recurrence[]` RRULE strings
+  - `reminders` with `use_default` and `overrides[]`
+- Extracted `mapEventToOutput()` helper for consistent event serialization
+- All optional fields use omit-if-empty pattern to keep output compact
+
+### Docs
+- Updated calendar skill docs (SKILL.md v1.1.0, commands.md) with full field reference
+- Fixed auth setup guide: "all scopes upfront" → scoped auth description (v1.16.0 follow-up)
+
 ## v1.16.0
 
 **Security Hardening + Scoped Auth**

--- a/skills/auth/references/setup-guide.md
+++ b/skills/auth/references/setup-guide.md
@@ -144,7 +144,7 @@ gws gmail list --max 3
 | `~/.config/gws/token.json` | OAuth token (auto-refreshes) |
 
 - Tokens auto-refresh when expired
-- All scopes are requested upfront during login
+- Scopes are requested based on the `--services` flag, config defaults, or all scopes by default
 - To re-authenticate: `gws auth logout` then `gws auth login`
 - To switch accounts: logout and login with a different Google account
 

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gws-calendar
-version: 1.0.0
+version: 1.1.0
 description: "Google Calendar CLI operations via gws. Use when users need to list calendars, view events, create/update/delete events, or RSVP to invitations. Triggers: calendar, events, meetings, schedule, rsvp, invite."
 metadata:
   short-description: Google Calendar CLI operations
@@ -65,9 +65,19 @@ Lists upcoming events from a calendar.
 - `--max int` — Maximum number of events (default 50)
 - `--pending` — Only show events with pending RSVP (needsAction). Tip: increase `--max` when using `--pending` over long date ranges, since `--max` limits the API fetch before client-side filtering.
 
-**Output includes:**
-- `response_status` — User's RSVP status (`accepted`, `declined`, `tentative`, `needsAction`) when user is an attendee
-- `organizer` — Organizer's email address
+**Output includes** (fields omitted when empty):
+
+| Category | Fields |
+|----------|--------|
+| **Core** | `id`, `summary`, `status` |
+| **Time** | `start`, `end`, `all_day` |
+| **Details** | `description`, `location`, `hangout_link`, `html_link`, `created`, `updated`, `color_id`, `visibility`, `transparency`, `event_type` |
+| **People** | `organizer` (email), `creator` (email), `response_status` (your RSVP) |
+| **Attendees** | `attendees[]` — `{ email, response_status, optional, organizer, self }` |
+| **Conference** | `conference` — `{ conference_id, solution, entry_points[]: { type, uri } }` |
+| **Attachments** | `attachments[]` — `{ file_url, title, mime_type, file_id }` |
+| **Recurrence** | `recurrence[]` — RRULE strings |
+| **Reminders** | `reminders` — `{ use_default, overrides[]: { method, minutes } }` |
 
 **Examples:**
 ```bash

--- a/skills/calendar/references/commands.md
+++ b/skills/calendar/references/commands.md
@@ -29,8 +29,8 @@ No additional flags.
 Returns an array of calendars with:
 - `id` — Calendar ID (e.g., `primary`, `user@group.calendar.google.com`)
 - `summary` — Calendar name
-- `description` — Calendar description
-- `accessRole` — Your access level (`owner`, `writer`, `reader`)
+- `primary` — `true` if this is the user's primary calendar
+- `description` — Calendar description (if set)
 
 ---
 
@@ -51,17 +51,49 @@ Usage: gws calendar events [flags]
 
 ### Output Fields (JSON)
 
-Each event includes:
+Fields are omitted when empty/nil to keep output compact.
+
+**Core:**
 - `id` — Event ID (used for update/delete/rsvp)
 - `summary` — Event title
+- `status` — Event status (`confirmed`, `tentative`, `cancelled`)
+
+**Time:**
 - `start` — Start time (dateTime or date for all-day events)
 - `end` — End time
-- `status` — Event status (confirmed, tentative, cancelled)
-- `location` — Event location (if set)
-- `hangout_link` — Google Meet link (if set)
-- `organizer` — Organizer email address (if set)
-- `response_status` — User's RSVP status: `accepted`, `declined`, `tentative`, `needsAction` (if user is an attendee)
 - `all_day` — `true` for all-day events (omitted for timed events)
+
+**Details:**
+- `description` — Event description (HTML allowed by Google)
+- `location` — Event location
+- `hangout_link` — Legacy Hangouts link
+- `html_link` — Link to event in Google Calendar web UI
+- `created` — Creation timestamp
+- `updated` — Last-modified timestamp
+- `color_id` — Calendar color ID
+- `visibility` — `default`, `public`, `private`, `confidential`
+- `transparency` — `opaque` (busy) or `transparent` (free)
+- `event_type` — `default`, `outOfOffice`, `focusTime`, `workingLocation`
+
+**People:**
+- `organizer` — Organizer email address
+- `creator` — Event creator email address
+- `response_status` — Current user's RSVP status: `accepted`, `declined`, `tentative`, `needsAction`
+
+**Attendees:**
+- `attendees[]` — Full attendee list, each with: `email`, `response_status`, `optional` (bool), `organizer` (bool), `self` (bool)
+
+**Conference:**
+- `conference` — `{ conference_id, solution, entry_points[]: { type, uri } }`
+
+**Attachments:**
+- `attachments[]` — `{ file_url, title, mime_type, file_id }`
+
+**Recurrence:**
+- `recurrence[]` — RRULE/EXRULE/RDATE/EXDATE strings
+
+**Reminders:**
+- `reminders` — `{ use_default (bool), overrides[]: { method, minutes } }`
 
 ---
 


### PR DESCRIPTION
## Summary
- Extract `mapEventToOutput()` helper with expanded field coverage: description, attendees, conference data, attachments, recurrence, reminders, timestamps, visibility, transparency, event type, creator
- All optional fields use omit-if-empty pattern with nil guards on nested slice elements
- Fix auth docs ("all scopes upfront" → scoped auth) and calendar list output docs (`accessRole` → `primary`)
- Bump to v1.17.0

## Test plan
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass (8 new/updated test cases)
- [x] `TestMapEventToOutput_AllFields` — verifies all new fields appear when set
- [x] `TestMapEventToOutput_EmptyOptionals` — verifies empty fields omitted
- [x] `TestMapEventToOutput_AllDayEvent` — all-day event through helper
- [x] `TestMapEventToOutput_NilNestedEntries` — nil elements safely skipped
- [x] `TestMapEventToOutput_EmptyNestedObjects` — fully-empty nested structs omitted
- [x] `TestMapEventToOutput_EmptyMethodOverride` — empty-method overrides skipped
- [ ] Manual: `gws calendar events --days 1` — verify new fields in real output
- [ ] Manual: `gws calendar events --pending` — still filters correctly

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)