### PR TITLE
feat(chat): add members command (v1.18.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.17.0
+VERSION ?= 1.18.0
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Add `--format text` for human-readable output, or `--format yaml` for YAML.
 |---------|-------------|
 | `gws chat list` | List spaces |
 | `gws chat messages <space>` | List messages in a space |
+| `gws chat members <space>` | List members with display names (`--max`) |
 | `gws chat send` | Send message (`--space`, `--text`) |
 
 ### Forms

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,16 @@
 # Releases
 
+## v1.18.0
+
+**Chat Members**
+
+### Chat
+- `gws chat members <space-id>` — List all members of a Chat space with display names, roles, and user types
+  - Uses `chat.memberships.readonly` scope (added in v1.16.0)
+  - Returns `display_name`, `user` (resource name), `type` (HUMAN/BOT), `role`, `joined` (fields omitted when empty)
+  - Paginates automatically; `--max` caps total results
+  - `--max` flag for pagination (default 100)
+
 ## v1.17.0
 
 **Full Calendar Event Fields**

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -225,6 +226,218 @@ func TestChatMessages_SenderFallback(t *testing.T) {
 	}
 	if resp.Messages[0].Sender.Name != "users/999" {
 		t.Errorf("expected sender name 'users/999', got '%s'", resp.Messages[0].Sender.Name)
+	}
+}
+
+func TestChatMembersCommand_Flags(t *testing.T) {
+	membersCmd := findSubcommand(chatCmd, "members")
+	if membersCmd == nil {
+		t.Fatal("chat members command not found")
+	}
+	if membersCmd.Args == nil {
+		t.Error("expected Args validator to be set")
+	}
+	maxFlag := membersCmd.Flags().Lookup("max")
+	if maxFlag == nil {
+		t.Fatal("expected --max flag")
+	}
+	if maxFlag.DefValue != "100" {
+		t.Errorf("expected --max default '100', got '%s'", maxFlag.DefValue)
+	}
+}
+
+func TestChatMembers_MockServer(t *testing.T) {
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/members": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "GET" {
+				t.Errorf("expected GET, got %s", r.Method)
+			}
+			resp := map[string]interface{}{
+				"memberships": []map[string]interface{}{
+					{
+						"name":       "spaces/AAAA/members/111",
+						"role":       "ROLE_MEMBER",
+						"createTime": "2025-01-01T00:00:00Z",
+						"member":     map[string]interface{}{"displayName": "Alice Smith", "name": "users/111", "type": "HUMAN"},
+					},
+					{
+						"name":       "spaces/AAAA/members/222",
+						"role":       "ROLE_MANAGER",
+						"createTime": "2025-01-02T00:00:00Z",
+						"member":     map[string]interface{}{"displayName": "Bob Jones", "name": "users/222", "type": "HUMAN"},
+					},
+					{
+						"name":   "spaces/AAAA/members/bot1",
+						"role":   "ROLE_MEMBER",
+						"member": map[string]interface{}{"displayName": "Helper Bot", "name": "users/bot1", "type": "BOT"},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	resp, err := svc.Spaces.Members.List("spaces/AAAA").PageSize(100).Do()
+	if err != nil {
+		t.Fatalf("failed to list members: %v", err)
+	}
+
+	if len(resp.Memberships) != 3 {
+		t.Fatalf("expected 3 members, got %d", len(resp.Memberships))
+	}
+	if resp.Memberships[0].Member.DisplayName != "Alice Smith" {
+		t.Errorf("expected first member 'Alice Smith', got '%s'", resp.Memberships[0].Member.DisplayName)
+	}
+	if resp.Memberships[1].Role != "ROLE_MANAGER" {
+		t.Errorf("expected second member role 'ROLE_MANAGER', got '%s'", resp.Memberships[1].Role)
+	}
+	if resp.Memberships[2].Member.Type != "BOT" {
+		t.Errorf("expected third member type 'BOT', got '%s'", resp.Memberships[2].Member.Type)
+	}
+}
+
+// TestChatMembers_PaginationStopsAtMax verifies the Pages iterator stops after --max is reached
+func TestChatMembers_PaginationStopsAtMax(t *testing.T) {
+	pagesFetched := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path != "/v1/spaces/BIGSPACE/members" {
+			t.Logf("Unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		pagesFetched++
+		pageToken := r.URL.Query().Get("pageToken")
+
+		if pageToken == "" {
+			// Page 1: return 3 members + nextPageToken
+			resp := map[string]interface{}{
+				"memberships": []map[string]interface{}{
+					{"name": "spaces/BIGSPACE/members/1", "role": "ROLE_MEMBER", "member": map[string]interface{}{"displayName": "User 1", "name": "users/1", "type": "HUMAN"}},
+					{"name": "spaces/BIGSPACE/members/2", "role": "ROLE_MEMBER", "member": map[string]interface{}{"displayName": "User 2", "name": "users/2", "type": "HUMAN"}},
+					{"name": "spaces/BIGSPACE/members/3", "role": "ROLE_MEMBER", "member": map[string]interface{}{"displayName": "User 3", "name": "users/3", "type": "HUMAN"}},
+				},
+				"nextPageToken": "page2",
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		// Page 2: should NOT be fetched if max=2
+		resp := map[string]interface{}{
+			"memberships": []map[string]interface{}{
+				{"name": "spaces/BIGSPACE/members/4", "role": "ROLE_MEMBER", "member": map[string]interface{}{"displayName": "User 4", "name": "users/4", "type": "HUMAN"}},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	// Simulate runChatMembers logic with max=2
+	maxResults := int64(2)
+	pageSize := maxResults
+	var results []map[string]interface{}
+
+	errDone := fmt.Errorf("done")
+	err = svc.Spaces.Members.List("spaces/BIGSPACE").PageSize(pageSize).Pages(context.Background(), func(resp *chat.ListMembershipsResponse) error {
+		for _, m := range resp.Memberships {
+			if m == nil {
+				continue
+			}
+			if int64(len(results)) >= maxResults {
+				return errDone
+			}
+			results = append(results, mapMemberToOutput(m))
+		}
+		if int64(len(results)) >= maxResults {
+			return errDone
+		}
+		return nil
+	})
+	if err != nil && err != errDone {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 results (capped by max), got %d", len(results))
+	}
+	if pagesFetched != 1 {
+		t.Errorf("expected only 1 page fetched (early stop), got %d", pagesFetched)
+	}
+}
+
+func TestMapMemberToOutput_AllFields(t *testing.T) {
+	m := &chat.Membership{
+		Name:       "spaces/AAAA/members/111",
+		Role:       "ROLE_MANAGER",
+		CreateTime: "2025-06-01T00:00:00Z",
+		Member: &chat.User{
+			DisplayName: "Alice Smith",
+			Name:        "users/111",
+			Type:        "HUMAN",
+		},
+	}
+
+	result := mapMemberToOutput(m)
+
+	if result["name"] != "spaces/AAAA/members/111" {
+		t.Errorf("expected name, got %v", result["name"])
+	}
+	if result["display_name"] != "Alice Smith" {
+		t.Errorf("expected display_name 'Alice Smith', got %v", result["display_name"])
+	}
+	if result["user"] != "users/111" {
+		t.Errorf("expected user 'users/111', got %v", result["user"])
+	}
+	if result["type"] != "HUMAN" {
+		t.Errorf("expected type 'HUMAN', got %v", result["type"])
+	}
+	if result["role"] != "ROLE_MANAGER" {
+		t.Errorf("expected role 'ROLE_MANAGER', got %v", result["role"])
+	}
+	if result["joined"] != "2025-06-01T00:00:00Z" {
+		t.Errorf("expected joined time, got %v", result["joined"])
+	}
+}
+
+func TestMapMemberToOutput_MinimalFields(t *testing.T) {
+	m := &chat.Membership{
+		Name: "spaces/AAAA/members/222",
+		Role: "ROLE_MEMBER",
+	}
+
+	result := mapMemberToOutput(m)
+
+	if result["name"] != "spaces/AAAA/members/222" {
+		t.Errorf("expected name, got %v", result["name"])
+	}
+	if _, exists := result["display_name"]; exists {
+		t.Error("display_name should be omitted when Member is nil")
+	}
+	if _, exists := result["user"]; exists {
+		t.Error("user should be omitted when Member is nil")
+	}
+	if _, exists := result["type"]; exists {
+		t.Error("type should be omitted when Member is nil")
+	}
+	if _, exists := result["joined"]; exists {
+		t.Error("joined should be omitted when CreateTime is empty")
 	}
 }
 

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gws-chat
-version: 1.0.1
+version: 1.1.0
 description: "Google Chat CLI operations via gws. Use when users need to list chat spaces, read messages, or send messages in Google Chat. Triggers: google chat, gchat, chat spaces, chat messages."
 metadata:
   short-description: Google Chat CLI operations
@@ -40,6 +40,7 @@ For initial setup, see the `gws-auth` skill.
 | List chat spaces | `gws chat list` |
 | Read messages | `gws chat messages <space-id>` |
 | Read recent messages | `gws chat messages <space-id> --max 10` |
+| List space members | `gws chat members <space-id>` |
 | Send a message | `gws chat send --space <space-id> --text "Hello"` |
 
 ## Detailed Usage
@@ -60,6 +61,24 @@ gws chat messages <space-id> [flags]
 
 **Flags:**
 - `--max int` — Maximum number of messages to return (default 25)
+
+### members — List space members
+
+```bash
+gws chat members <space-id> [flags]
+```
+
+Lists all members of a Chat space with display names, roles, and user types.
+
+**Flags:**
+- `--max int` — Maximum number of members to return (default 100)
+
+**Output includes:**
+- `display_name` — Member's display name
+- `user` — User resource name (e.g., `users/123456789`)
+- `type` — `HUMAN` or `BOT`
+- `role` — `ROLE_MEMBER` or `ROLE_MANAGER`
+- `joined` — When the member joined the space
 
 ### send — Send a message
 

--- a/skills/chat/references/commands.md
+++ b/skills/chat/references/commands.md
@@ -57,6 +57,34 @@ The space ID format is `spaces/AAAA1234` (get from `gws chat list`).
 
 ---
 
+## gws chat members
+
+Lists all members of a Chat space with display names.
+
+```
+Usage: gws chat members <space-id> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--max` | int | 100 | Maximum number of members to return |
+
+The space ID format is `spaces/AAAA1234` (get from `gws chat list`).
+
+Requires the `chat.memberships.readonly` scope (included by default since v1.16.0).
+
+### Output Fields (JSON)
+
+Each member includes (optional fields omitted when empty):
+- `name` — Membership resource name (e.g., `spaces/AAAA/members/111`)
+- `role` — `ROLE_MEMBER` or `ROLE_MANAGER`
+- `display_name` — Member's display name (if available)
+- `user` — User resource name, e.g., `users/123456789` (if available)
+- `type` — User type: `HUMAN` or `BOT` (if available)
+- `joined` — Membership creation timestamp (if available)
+
+---
+
 ## gws chat send
 
 Sends a text message to a Chat space.


### PR DESCRIPTION
## Summary
- New `gws chat members <space-id>` command — lists all members of a Chat space with display names
- Uses `chat.memberships.readonly` scope (added in v1.16.0, now wired up)
- Returns: `display_name`, `user` (resource name), `type` (HUMAN/BOT), `role`, `joined`
- `--max` flag for pagination (default 100)
- Updated chat skill docs (SKILL.md v1.1.0, commands.md)
- Bump to v1.18.0

## Test plan
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `TestChatMembersCommand_Flags` — validates command registration and flag defaults
- [x] `TestChatMembers_MockServer` — verifies display names, roles, and types from API
- [ ] Manual: `gws chat members spaces/AAAA0gJT9FU` — verify real output with display names

🤖 Generated with [Claude Code](https://claude.com/claude-code)