### PR TITLE
feat(chat): auto-resolve member names via People API + cache (v1.18.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.18.0
+VERSION ?= 1.18.1
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,15 @@
 # Releases
 
+## v1.18.1
+
+**Chat Member Name Resolution**
+
+- `gws chat members` now auto-resolves display names and emails via People API
+  - Persistent cache at `~/.config/gws/user-cache.json` — grows over time, avoids repeat API calls
+  - Batch resolution (up to 50 per request) via `people.getBatchGet`
+  - Best-effort: gracefully degrades if People API is unavailable
+- New `internal/usercache` package for reusable user ID → name caching
+
 ## v1.18.0
 
 **Chat Members**

--- a/internal/usercache/cache.go
+++ b/internal/usercache/cache.go
@@ -1,0 +1,158 @@
+package usercache
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"google.golang.org/api/people/v1"
+)
+
+// UserInfo stores resolved user metadata.
+type UserInfo struct {
+	DisplayName string `json:"display_name"`
+	Email       string `json:"email,omitempty"`
+}
+
+// Cache provides a persistent user ID → display name cache.
+type Cache struct {
+	mu      sync.Mutex
+	path    string
+	entries map[string]UserInfo
+}
+
+// New loads or creates a user cache at ~/.config/gws/user-cache.json.
+func New() (*Cache, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(home, ".config", "gws", "user-cache.json")
+
+	c := &Cache{
+		path:    path,
+		entries: make(map[string]UserInfo),
+	}
+
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if jsonErr := json.Unmarshal(data, &c.entries); jsonErr != nil {
+			// Corrupted cache — log and start fresh
+			fmt.Fprintf(os.Stderr, "warning: user cache corrupted, resetting: %v\n", jsonErr)
+			c.entries = make(map[string]UserInfo)
+		}
+	}
+
+	return c, nil
+}
+
+// Get returns cached info for a user ID (e.g., "users/123"), or false if not cached.
+func (c *Cache) Get(userID string) (UserInfo, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	info, ok := c.entries[userID]
+	return info, ok
+}
+
+// Set stores a user entry.
+func (c *Cache) Set(userID string, info UserInfo) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[userID] = info
+}
+
+// Save persists the cache to disk using atomic temp-file + rename.
+func (c *Cache) Save() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	dir := filepath.Dir(c.path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(c.entries, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp := c.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, c.path)
+}
+
+// ResolveMany looks up unknown user IDs via the People API in batches.
+// Only processes IDs with the "users/" prefix. Skips bots and invalid IDs.
+// Caches results including email-only entries (no display name required).
+func (c *Cache) ResolveMany(peopleSvc *people.Service, userIDs []string) {
+	if peopleSvc == nil {
+		return
+	}
+
+	// Filter to only unknown IDs with valid "users/" prefix
+	var unknown []string
+	for _, id := range userIDs {
+		if !strings.HasPrefix(id, "users/") {
+			continue
+		}
+		if _, ok := c.Get(id); !ok {
+			unknown = append(unknown, id)
+		}
+	}
+
+	if len(unknown) == 0 {
+		return
+	}
+
+	// People API getBatchGet supports up to 50 resource names per call
+	for i := 0; i < len(unknown); i += 50 {
+		end := i + 50
+		if end > len(unknown) {
+			end = len(unknown)
+		}
+		batch := unknown[i:end]
+
+		// Convert "users/123" to "people/123" for People API
+		resourceNames := make([]string, len(batch))
+		for j, id := range batch {
+			resourceNames[j] = "people/" + strings.TrimPrefix(id, "users/")
+		}
+
+		resp, err := peopleSvc.People.GetBatchGet().
+			ResourceNames(resourceNames...).
+			PersonFields("names,emailAddresses").
+			Do()
+		if err != nil {
+			continue // Best-effort: skip batch on error
+		}
+
+		for _, pr := range resp.Responses {
+			if pr.Person == nil || pr.Person.ResourceName == "" {
+				continue
+			}
+			if !strings.HasPrefix(pr.Person.ResourceName, "people/") {
+				continue
+			}
+			userID := "users/" + strings.TrimPrefix(pr.Person.ResourceName, "people/")
+
+			info := UserInfo{}
+			if len(pr.Person.Names) > 0 {
+				info.DisplayName = pr.Person.Names[0].DisplayName
+			}
+			if len(pr.Person.EmailAddresses) > 0 {
+				info.Email = pr.Person.EmailAddresses[0].Value
+			}
+			// Cache if we got any useful data (name or email)
+			if info.DisplayName != "" || info.Email != "" {
+				c.Set(userID, info)
+			}
+		}
+	}
+
+	_ = c.Save()
+}

--- a/internal/usercache/cache_test.go
+++ b/internal/usercache/cache_test.go
@@ -1,0 +1,150 @@
+package usercache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func tempCache(t *testing.T) *Cache {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "user-cache.json")
+	return &Cache{
+		path:    path,
+		entries: make(map[string]UserInfo),
+	}
+}
+
+func TestCache_GetSet(t *testing.T) {
+	c := tempCache(t)
+
+	// Miss
+	_, ok := c.Get("users/123")
+	if ok {
+		t.Error("expected miss on empty cache")
+	}
+
+	// Set and hit
+	c.Set("users/123", UserInfo{DisplayName: "Alice", Email: "alice@example.com"})
+	info, ok := c.Get("users/123")
+	if !ok {
+		t.Fatal("expected hit after set")
+	}
+	if info.DisplayName != "Alice" {
+		t.Errorf("expected 'Alice', got %q", info.DisplayName)
+	}
+	if info.Email != "alice@example.com" {
+		t.Errorf("expected 'alice@example.com', got %q", info.Email)
+	}
+}
+
+func TestCache_SaveAndReload(t *testing.T) {
+	c := tempCache(t)
+	c.Set("users/1", UserInfo{DisplayName: "Bob", Email: "bob@example.com"})
+	c.Set("users/2", UserInfo{DisplayName: "Carol"})
+
+	if err := c.Save(); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	// Read back the file
+	data, err := os.ReadFile(c.path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+
+	var loaded map[string]UserInfo
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(loaded) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(loaded))
+	}
+	if loaded["users/1"].DisplayName != "Bob" {
+		t.Errorf("expected 'Bob', got %q", loaded["users/1"].DisplayName)
+	}
+	if loaded["users/2"].Email != "" {
+		t.Errorf("expected empty email for Carol, got %q", loaded["users/2"].Email)
+	}
+}
+
+func TestCache_AtomicSave(t *testing.T) {
+	c := tempCache(t)
+	c.Set("users/1", UserInfo{DisplayName: "First"})
+
+	if err := c.Save(); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	// Verify no .tmp file remains
+	tmpPath := c.path + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Error("temp file should not exist after successful save")
+	}
+
+	// Verify the file is valid JSON
+	data, _ := os.ReadFile(c.path)
+	var entries map[string]UserInfo
+	if err := json.Unmarshal(data, &entries); err != nil {
+		t.Fatalf("saved file is not valid JSON: %v", err)
+	}
+}
+
+func TestCache_CorruptedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "user-cache.json")
+
+	// Write corrupt JSON
+	os.WriteFile(path, []byte("{invalid json!!!"), 0600)
+
+	// New() should not fail, just start fresh
+	c := &Cache{
+		path:    path,
+		entries: make(map[string]UserInfo),
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed: %v", err)
+	}
+	if jsonErr := json.Unmarshal(data, &c.entries); jsonErr != nil {
+		// Expected — reset
+		c.entries = make(map[string]UserInfo)
+	}
+
+	if len(c.entries) != 0 {
+		t.Error("expected empty cache after corrupt file")
+	}
+
+	// Should be able to set and save normally
+	c.Set("users/1", UserInfo{DisplayName: "Recovered"})
+	if err := c.Save(); err != nil {
+		t.Fatalf("save after corrupt failed: %v", err)
+	}
+}
+
+func TestResolveMany_NilService(t *testing.T) {
+	c := tempCache(t)
+
+	// Must not panic
+	c.ResolveMany(nil, []string{"users/123"})
+
+	_, ok := c.Get("users/123")
+	if ok {
+		t.Error("should not resolve with nil service")
+	}
+}
+
+func TestResolveMany_SkipsInvalidPrefixes(t *testing.T) {
+	c := tempCache(t)
+
+	// IDs without "users/" prefix should be skipped
+	c.ResolveMany(nil, []string{"bots/abc", "apps/xyz", ""})
+
+	// No entries should be added (and no panic)
+	if _, ok := c.Get("bots/abc"); ok {
+		t.Error("should not cache non-user IDs")
+	}
+}


### PR DESCRIPTION
## Summary
- `gws chat members` now auto-resolves display names and emails via People API `getBatchGet`
- Persistent cache at `~/.config/gws/user-cache.json` — grows over time, avoids repeat API calls
- Batch resolution (50 per request), best-effort graceful degradation
- New `internal/usercache` package

## Test plan
- [x] `go vet ./...` + `go test ./...` — all pass
- [x] Manual: `gws chat members spaces/AAAA0gJT9FU` — display names + emails resolved
- [x] Manual: cache file created at `~/.config/gws/user-cache.json` with 5 entries
- [x] Manual: second run uses cache (no People API calls for known IDs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)