### PR TITLE
feat(chat): expose full Chat API parameters and add CRUD + reactions (#87)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@
 | `docs` | read, info, create, append, insert, replace, delete, add-table, format, set-paragraph-style, add-list, remove-list |
 | `sheets` | info, list, read, create, write, append, add-sheet, delete-sheet, clear, insert-rows, delete-rows, insert-cols, delete-cols, rename-sheet, duplicate-sheet, merge, unmerge, sort, find-replace, format, set-column-width, set-row-height, freeze |
 | `slides` | info, list, read, create, add-slide, delete-slide, duplicate-slide, add-shape, add-image, add-text, replace-text, delete-object, delete-text, update-text-style, update-transform, create-table, insert-table-rows, delete-table-row, update-table-cell, update-table-border, update-paragraph-style, update-shape, reorder-slides |
-| `chat` | list, messages, send (needs Chat App config) |
+| `chat` | list, messages, members, send, get, update, delete, reactions, react, unreact |
 | `contacts` | list, search, get, create, delete |
 | `forms` | info, responses |
 | `search` | web search (needs API key) |
@@ -46,7 +46,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.15.0** - Slides API parity (backgrounds, layouts, lines, groups), per-element text ops, drive copy, chat sender fix.
+**v1.19.0** - Chat API full parameter exposure: filter/order/pagination on list/messages/members, new get/update/delete/reactions/react/unreact commands.
 
 ## Roadmap
 
@@ -65,3 +65,15 @@ When adding new commands:
 4. Add command name to `TestXxxCommands` in `cmd/commands_test.go`
 5. Update README.md command table
 6. Bump version in Makefile
+
+## Development Workflow
+
+Every feature/fix follows this flow:
+
+1. **Branch** — Create a feature branch from `main` (e.g. `feat/chat-api-params`)
+2. **Implement & commit** — Make changes, commit with clear messages
+3. **Open PR** — Push branch and open a PR against `main`
+4. **Codex review loop** — Use Codex to review the PR; iterate on feedback until it approves
+5. **Merge** — Merge the PR into `main`
+6. **Release** — Bump version in Makefile, update CLAUDE.md version, tag release, update README
+7. **Tweet draft** — Write a short tweet announcing the new version and key changes

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.18.1
+VERSION ?= 1.19.0
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/README.md
+++ b/README.md
@@ -225,10 +225,16 @@ Add `--format text` for human-readable output, or `--format yaml` for YAML.
 
 | Command | Description |
 |---------|-------------|
-| `gws chat list` | List spaces |
-| `gws chat messages <space>` | List messages in a space |
-| `gws chat members <space>` | List members with display names + emails via People API, cached locally (`--max`) |
+| `gws chat list` | List spaces (`--filter`, `--page-size`) |
+| `gws chat messages <space>` | List messages (`--max`, `--filter`, `--order-by`, `--show-deleted`) |
+| `gws chat members <space>` | List members with display names + emails via People API (`--max`, `--filter`, `--show-groups`, `--show-invited`) |
 | `gws chat send` | Send message (`--space`, `--text`) |
+| `gws chat get <message>` | Get a single message |
+| `gws chat update <message>` | Update message text (`--text`) |
+| `gws chat delete <message>` | Delete a message (`--force`) |
+| `gws chat reactions <message>` | List reactions (`--filter`, `--page-size`) |
+| `gws chat react <message>` | Add emoji reaction (`--emoji`) |
+| `gws chat unreact <reaction>` | Remove a reaction |
 
 ### Forms
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/omriariav/workspace-cli/internal/client"
 	"github.com/omriariav/workspace-cli/internal/printer"
@@ -54,24 +55,111 @@ var chatSendCmd = &cobra.Command{
 	RunE:  runChatSend,
 }
 
+var chatGetCmd = &cobra.Command{
+	Use:   "get <message-name>",
+	Short: "Get a single message",
+	Long:  "Retrieves a single message by its resource name (e.g. spaces/AAAA/messages/msg1).",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChatGet,
+}
+
+var chatUpdateCmd = &cobra.Command{
+	Use:   "update <message-name>",
+	Short: "Update a message",
+	Long:  "Updates the text of an existing message.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChatUpdate,
+}
+
+var chatDeleteCmd = &cobra.Command{
+	Use:   "delete <message-name>",
+	Short: "Delete a message",
+	Long:  "Deletes a message by its resource name.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChatDelete,
+}
+
+var chatReactionsCmd = &cobra.Command{
+	Use:   "reactions <message-name>",
+	Short: "List reactions on a message",
+	Long:  "Lists all reactions on a message.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChatReactions,
+}
+
+var chatReactCmd = &cobra.Command{
+	Use:   "react <message-name>",
+	Short: "Add a reaction to a message",
+	Long:  "Adds an emoji reaction to a message.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChatReact,
+}
+
+var chatUnreactCmd = &cobra.Command{
+	Use:   "unreact <reaction-name>",
+	Short: "Remove a reaction",
+	Long:  "Removes a reaction by its resource name (e.g. spaces/AAAA/messages/msg1/reactions/rxn1).",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runChatUnreact,
+}
+
 func init() {
 	rootCmd.AddCommand(chatCmd)
 	chatCmd.AddCommand(chatListCmd)
 	chatCmd.AddCommand(chatMessagesCmd)
 	chatCmd.AddCommand(chatSendCmd)
 	chatCmd.AddCommand(chatMembersCmd)
+	chatCmd.AddCommand(chatGetCmd)
+	chatCmd.AddCommand(chatUpdateCmd)
+	chatCmd.AddCommand(chatDeleteCmd)
+	chatCmd.AddCommand(chatReactionsCmd)
+	chatCmd.AddCommand(chatReactCmd)
+	chatCmd.AddCommand(chatUnreactCmd)
+
+	// List flags
+	chatListCmd.Flags().String("filter", "", "Filter spaces (e.g. 'spaceType = \"SPACE\"')")
+	chatListCmd.Flags().Int64("page-size", 100, "Number of spaces per page")
 
 	// Members flags
 	chatMembersCmd.Flags().Int64("max", 100, "Maximum number of members to return")
+	chatMembersCmd.Flags().String("filter", "", "Filter members (e.g. 'member.type = \"HUMAN\"')")
+	chatMembersCmd.Flags().Bool("show-groups", false, "Include Google Group memberships")
+	chatMembersCmd.Flags().Bool("show-invited", false, "Include invited memberships")
 
 	// Messages flags
 	chatMessagesCmd.Flags().Int64("max", 25, "Maximum number of messages to return")
+	chatMessagesCmd.Flags().String("filter", "", "Filter messages (e.g. 'createTime > \"2024-01-01T00:00:00Z\"')")
+	chatMessagesCmd.Flags().String("order-by", "", "Order messages (e.g. 'createTime DESC')")
+	chatMessagesCmd.Flags().Bool("show-deleted", false, "Include deleted messages in results")
 
 	// Send flags
 	chatSendCmd.Flags().String("space", "", "Space ID or name (required)")
 	chatSendCmd.Flags().String("text", "", "Message text (required)")
 	chatSendCmd.MarkFlagRequired("space")
 	chatSendCmd.MarkFlagRequired("text")
+
+	// Update flags
+	chatUpdateCmd.Flags().String("text", "", "New message text (required)")
+	chatUpdateCmd.MarkFlagRequired("text")
+
+	// Delete flags
+	chatDeleteCmd.Flags().Bool("force", false, "Force delete (even if message has replies)")
+
+	// Reactions flags
+	chatReactionsCmd.Flags().String("filter", "", "Filter reactions (e.g. 'emoji.unicode = \"😀\"')")
+	chatReactionsCmd.Flags().Int64("page-size", 25, "Number of reactions per page")
+
+	// React flags
+	chatReactCmd.Flags().String("emoji", "", "Emoji unicode character (required, e.g. '😀')")
+	chatReactCmd.MarkFlagRequired("emoji")
+}
+
+// ensureSpaceName normalizes a space identifier to its full resource name.
+func ensureSpaceName(s string) string {
+	if !strings.HasPrefix(s, "spaces/") {
+		return "spaces/" + s
+	}
+	return s
 }
 
 func runChatList(cmd *cobra.Command, args []string) error {
@@ -88,22 +176,42 @@ func runChatList(cmd *cobra.Command, args []string) error {
 		return p.PrintError(err)
 	}
 
-	resp, err := svc.Spaces.List().Do()
-	if err != nil {
-		return p.PrintError(fmt.Errorf("failed to list spaces: %w", err))
-	}
+	filter, _ := cmd.Flags().GetString("filter")
+	pageSize, _ := cmd.Flags().GetInt64("page-size")
 
-	results := make([]map[string]interface{}, 0, len(resp.Spaces))
-	for _, space := range resp.Spaces {
-		spaceInfo := map[string]interface{}{
-			"name":         space.Name,
-			"display_name": space.DisplayName,
-			"type":         space.Type,
+	var results []map[string]interface{}
+	var pageToken string
+
+	for {
+		call := svc.Spaces.List().PageSize(pageSize)
+		if filter != "" {
+			call = call.Filter(filter)
 		}
-		if space.SpaceDetails != nil {
-			spaceInfo["description"] = space.SpaceDetails.Description
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
 		}
-		results = append(results, spaceInfo)
+
+		resp, err := call.Do()
+		if err != nil {
+			return p.PrintError(fmt.Errorf("failed to list spaces: %w", err))
+		}
+
+		for _, space := range resp.Spaces {
+			spaceInfo := map[string]interface{}{
+				"name":         space.Name,
+				"display_name": space.DisplayName,
+				"type":         space.Type,
+			}
+			if space.SpaceDetails != nil {
+				spaceInfo["description"] = space.SpaceDetails.Description
+			}
+			results = append(results, spaceInfo)
+		}
+
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
 	}
 
 	return p.Print(map[string]interface{}{
@@ -126,36 +234,68 @@ func runChatMessages(cmd *cobra.Command, args []string) error {
 		return p.PrintError(err)
 	}
 
-	spaceID := args[0]
+	spaceName := ensureSpaceName(args[0])
 	maxResults, _ := cmd.Flags().GetInt64("max")
+	filter, _ := cmd.Flags().GetString("filter")
+	orderBy, _ := cmd.Flags().GetString("order-by")
+	showDeleted, _ := cmd.Flags().GetBool("show-deleted")
 
-	// Ensure space name has correct format
-	spaceName := spaceID
-	if spaceName[:7] != "spaces/" {
-		spaceName = "spaces/" + spaceName
-	}
+	var results []map[string]interface{}
+	var pageToken string
 
-	resp, err := svc.Spaces.Messages.List(spaceName).PageSize(int64(maxResults)).Do()
-	if err != nil {
-		return p.PrintError(fmt.Errorf("failed to list messages: %w", err))
-	}
-
-	results := make([]map[string]interface{}, 0, len(resp.Messages))
-	for _, msg := range resp.Messages {
-		msgInfo := map[string]interface{}{
-			"name":        msg.Name,
-			"text":        msg.Text,
-			"create_time": msg.CreateTime,
+	for {
+		remaining := maxResults - int64(len(results))
+		pageSize := remaining
+		if pageSize > 1000 {
+			pageSize = 1000
 		}
-		if msg.Sender != nil {
-			senderName := msg.Sender.DisplayName
-			if senderName == "" {
-				senderName = msg.Sender.Name
+
+		call := svc.Spaces.Messages.List(spaceName).PageSize(pageSize)
+		if filter != "" {
+			call = call.Filter(filter)
+		}
+		if orderBy != "" {
+			call = call.OrderBy(orderBy)
+		}
+		if showDeleted {
+			call = call.ShowDeleted(true)
+		}
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			return p.PrintError(fmt.Errorf("failed to list messages: %w", err))
+		}
+
+		for _, msg := range resp.Messages {
+			if int64(len(results)) >= maxResults {
+				break
 			}
-			msgInfo["sender"] = senderName
-			msgInfo["sender_type"] = msg.Sender.Type
+			msgInfo := map[string]interface{}{
+				"name":        msg.Name,
+				"text":        msg.Text,
+				"create_time": msg.CreateTime,
+			}
+			if msg.Sender != nil {
+				senderName := msg.Sender.DisplayName
+				if senderName == "" {
+					senderName = msg.Sender.Name
+				}
+				msgInfo["sender"] = senderName
+				msgInfo["sender_type"] = msg.Sender.Type
+			}
+			if msg.DeleteTime != "" {
+				msgInfo["delete_time"] = msg.DeleteTime
+			}
+			results = append(results, msgInfo)
 		}
-		results = append(results, msgInfo)
+
+		if resp.NextPageToken == "" || int64(len(results)) >= maxResults {
+			break
+		}
+		pageToken = resp.NextPageToken
 	}
 
 	return p.Print(map[string]interface{}{
@@ -178,13 +318,11 @@ func runChatMembers(cmd *cobra.Command, args []string) error {
 		return p.PrintError(err)
 	}
 
-	spaceID := args[0]
+	spaceName := ensureSpaceName(args[0])
 	maxResults, _ := cmd.Flags().GetInt64("max")
-
-	spaceName := spaceID
-	if len(spaceName) < 7 || spaceName[:7] != "spaces/" {
-		spaceName = "spaces/" + spaceName
-	}
+	filter, _ := cmd.Flags().GetString("filter")
+	showGroups, _ := cmd.Flags().GetBool("show-groups")
+	showInvited, _ := cmd.Flags().GetBool("show-invited")
 
 	// Page size per request (Google caps at 100)
 	pageSize := maxResults
@@ -194,7 +332,19 @@ func runChatMembers(cmd *cobra.Command, args []string) error {
 
 	var results []map[string]interface{}
 	errDone := errors.New("done")
-	err = svc.Spaces.Members.List(spaceName).PageSize(pageSize).Pages(ctx, func(resp *chat.ListMembershipsResponse) error {
+
+	call := svc.Spaces.Members.List(spaceName).PageSize(pageSize)
+	if filter != "" {
+		call = call.Filter(filter)
+	}
+	if showGroups {
+		call = call.ShowGroups(true)
+	}
+	if showInvited {
+		call = call.ShowInvited(true)
+	}
+
+	err = call.Pages(ctx, func(resp *chat.ListMembershipsResponse) error {
 		for _, m := range resp.Memberships {
 			if m == nil {
 				continue
@@ -297,11 +447,7 @@ func runChatSend(cmd *cobra.Command, args []string) error {
 	spaceID, _ := cmd.Flags().GetString("space")
 	text, _ := cmd.Flags().GetString("text")
 
-	// Ensure space name has correct format
-	spaceName := spaceID
-	if len(spaceName) < 7 || spaceName[:7] != "spaces/" {
-		spaceName = "spaces/" + spaceName
-	}
+	spaceName := ensureSpaceName(spaceID)
 
 	msg := &chat.Message{
 		Text: text,
@@ -316,5 +462,243 @@ func runChatSend(cmd *cobra.Command, args []string) error {
 		"status":      "sent",
 		"name":        sent.Name,
 		"create_time": sent.CreateTime,
+	})
+}
+
+func runChatGet(cmd *cobra.Command, args []string) error {
+	p := printer.New(os.Stdout, GetFormat())
+	ctx := context.Background()
+
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Chat()
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	messageName := args[0]
+
+	msg, err := svc.Spaces.Messages.Get(messageName).Context(ctx).Do()
+	if err != nil {
+		return p.PrintError(fmt.Errorf("failed to get message: %w", err))
+	}
+
+	result := map[string]interface{}{
+		"name":        msg.Name,
+		"text":        msg.Text,
+		"create_time": msg.CreateTime,
+	}
+	if msg.Sender != nil {
+		senderName := msg.Sender.DisplayName
+		if senderName == "" {
+			senderName = msg.Sender.Name
+		}
+		result["sender"] = senderName
+		result["sender_type"] = msg.Sender.Type
+	}
+	if msg.Thread != nil {
+		result["thread"] = msg.Thread.Name
+	}
+
+	return p.Print(result)
+}
+
+func runChatUpdate(cmd *cobra.Command, args []string) error {
+	p := printer.New(os.Stdout, GetFormat())
+	ctx := context.Background()
+
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Chat()
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	messageName := args[0]
+	text, _ := cmd.Flags().GetString("text")
+
+	msg := &chat.Message{
+		Text: text,
+	}
+
+	updated, err := svc.Spaces.Messages.Patch(messageName, msg).UpdateMask("text").Context(ctx).Do()
+	if err != nil {
+		return p.PrintError(fmt.Errorf("failed to update message: %w", err))
+	}
+
+	return p.Print(map[string]interface{}{
+		"status":      "updated",
+		"name":        updated.Name,
+		"text":        updated.Text,
+		"create_time": updated.CreateTime,
+	})
+}
+
+func runChatDelete(cmd *cobra.Command, args []string) error {
+	p := printer.New(os.Stdout, GetFormat())
+	ctx := context.Background()
+
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Chat()
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	messageName := args[0]
+	force, _ := cmd.Flags().GetBool("force")
+
+	call := svc.Spaces.Messages.Delete(messageName).Context(ctx)
+	if force {
+		call = call.Force(true)
+	}
+
+	_, err = call.Do()
+	if err != nil {
+		return p.PrintError(fmt.Errorf("failed to delete message: %w", err))
+	}
+
+	return p.Print(map[string]interface{}{
+		"status": "deleted",
+		"name":   messageName,
+	})
+}
+
+func runChatReactions(cmd *cobra.Command, args []string) error {
+	p := printer.New(os.Stdout, GetFormat())
+	ctx := context.Background()
+
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Chat()
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	messageName := args[0]
+	filter, _ := cmd.Flags().GetString("filter")
+	pageSize, _ := cmd.Flags().GetInt64("page-size")
+
+	var results []map[string]interface{}
+	var pageToken string
+
+	for {
+		call := svc.Spaces.Messages.Reactions.List(messageName).PageSize(pageSize).Context(ctx)
+		if filter != "" {
+			call = call.Filter(filter)
+		}
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+
+		resp, err := call.Do()
+		if err != nil {
+			return p.PrintError(fmt.Errorf("failed to list reactions: %w", err))
+		}
+
+		for _, r := range resp.Reactions {
+			entry := map[string]interface{}{
+				"name": r.Name,
+			}
+			if r.Emoji != nil {
+				entry["emoji"] = r.Emoji.Unicode
+			}
+			if r.User != nil {
+				userName := r.User.DisplayName
+				if userName == "" {
+					userName = r.User.Name
+				}
+				entry["user"] = userName
+			}
+			results = append(results, entry)
+		}
+
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	return p.Print(map[string]interface{}{
+		"reactions": results,
+		"count":     len(results),
+	})
+}
+
+func runChatReact(cmd *cobra.Command, args []string) error {
+	p := printer.New(os.Stdout, GetFormat())
+	ctx := context.Background()
+
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Chat()
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	messageName := args[0]
+	emoji, _ := cmd.Flags().GetString("emoji")
+
+	reaction := &chat.Reaction{
+		Emoji: &chat.Emoji{
+			Unicode: emoji,
+		},
+	}
+
+	created, err := svc.Spaces.Messages.Reactions.Create(messageName, reaction).Context(ctx).Do()
+	if err != nil {
+		return p.PrintError(fmt.Errorf("failed to create reaction: %w", err))
+	}
+
+	result := map[string]interface{}{
+		"status": "reacted",
+		"name":   created.Name,
+	}
+	if created.Emoji != nil {
+		result["emoji"] = created.Emoji.Unicode
+	}
+
+	return p.Print(result)
+}
+
+func runChatUnreact(cmd *cobra.Command, args []string) error {
+	p := printer.New(os.Stdout, GetFormat())
+	ctx := context.Background()
+
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Chat()
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	reactionName := args[0]
+
+	_, err = svc.Spaces.Messages.Reactions.Delete(reactionName).Context(ctx).Do()
+	if err != nil {
+		return p.PrintError(fmt.Errorf("failed to delete reaction: %w", err))
+	}
+
+	return p.Print(map[string]interface{}{
+		"status": "unreacted",
+		"name":   reactionName,
 	})
 }

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -25,6 +25,18 @@ func TestChatCommands_Flags(t *testing.T) {
 	if maxFlag.DefValue != "25" {
 		t.Errorf("expected --max default '25', got '%s'", maxFlag.DefValue)
 	}
+	if messagesCmd.Flags().Lookup("filter") == nil {
+		t.Error("expected --filter flag on messages")
+	}
+	if messagesCmd.Flags().Lookup("order-by") == nil {
+		t.Error("expected --order-by flag on messages")
+	}
+	showDeleted := messagesCmd.Flags().Lookup("show-deleted")
+	if showDeleted == nil {
+		t.Error("expected --show-deleted flag on messages")
+	} else if showDeleted.DefValue != "false" {
+		t.Errorf("expected --show-deleted default 'false', got '%s'", showDeleted.DefValue)
+	}
 
 	// Test send command flags
 	sendCmd := findSubcommand(chatCmd, "send")
@@ -36,6 +48,21 @@ func TestChatCommands_Flags(t *testing.T) {
 	}
 	if sendCmd.Flags().Lookup("text") == nil {
 		t.Error("expected --text flag")
+	}
+
+	// Test list command flags
+	listCmd := findSubcommand(chatCmd, "list")
+	if listCmd == nil {
+		t.Fatal("chat list command not found")
+	}
+	if listCmd.Flags().Lookup("filter") == nil {
+		t.Error("expected --filter flag on list")
+	}
+	pageSizeFlag := listCmd.Flags().Lookup("page-size")
+	if pageSizeFlag == nil {
+		t.Error("expected --page-size flag on list")
+	} else if pageSizeFlag.DefValue != "100" {
+		t.Errorf("expected --page-size default '100', got '%s'", pageSizeFlag.DefValue)
 	}
 }
 
@@ -134,6 +161,101 @@ func TestChatList_MockServer(t *testing.T) {
 	}
 }
 
+func TestChatList_WithFilter(t *testing.T) {
+	var capturedFilter string
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces": func(w http.ResponseWriter, r *http.Request) {
+			capturedFilter = r.URL.Query().Get("filter")
+			resp := map[string]interface{}{
+				"spaces": []map[string]interface{}{
+					{"name": "spaces/AAAA", "displayName": "General", "type": "SPACE"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	filterStr := `spaceType = "SPACE"`
+	_, err = svc.Spaces.List().Filter(filterStr).Do()
+	if err != nil {
+		t.Fatalf("failed to list spaces with filter: %v", err)
+	}
+
+	if capturedFilter != filterStr {
+		t.Errorf("expected filter '%s', got '%s'", filterStr, capturedFilter)
+	}
+}
+
+func TestChatList_Pagination(t *testing.T) {
+	pagesFetched := 0
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces": func(w http.ResponseWriter, r *http.Request) {
+			pagesFetched++
+			pageToken := r.URL.Query().Get("pageToken")
+
+			if pageToken == "" {
+				resp := map[string]interface{}{
+					"spaces": []map[string]interface{}{
+						{"name": "spaces/AAAA", "displayName": "Space 1", "type": "ROOM"},
+					},
+					"nextPageToken": "page2",
+				}
+				json.NewEncoder(w).Encode(resp)
+				return
+			}
+
+			resp := map[string]interface{}{
+				"spaces": []map[string]interface{}{
+					{"name": "spaces/BBBB", "displayName": "Space 2", "type": "ROOM"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	// Simulate pagination loop from runChatList
+	var allSpaces []*chat.Space
+	var pageToken string
+	for {
+		call := svc.Spaces.List().PageSize(100)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		resp, err := call.Do()
+		if err != nil {
+			t.Fatalf("failed to list spaces: %v", err)
+		}
+		allSpaces = append(allSpaces, resp.Spaces...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	if pagesFetched != 2 {
+		t.Errorf("expected 2 pages fetched, got %d", pagesFetched)
+	}
+	if len(allSpaces) != 2 {
+		t.Errorf("expected 2 total spaces, got %d", len(allSpaces))
+	}
+}
+
 func TestChatMessages_MockServer(t *testing.T) {
 	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
 		"/v1/spaces/AAAA/messages": func(w http.ResponseWriter, r *http.Request) {
@@ -184,6 +306,111 @@ func TestChatMessages_MockServer(t *testing.T) {
 	}
 	if resp.Messages[0].Sender.Type != "HUMAN" {
 		t.Errorf("expected sender type 'HUMAN', got '%s'", resp.Messages[0].Sender.Type)
+	}
+}
+
+func TestChatMessages_WithOrderBy(t *testing.T) {
+	var capturedOrderBy string
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages": func(w http.ResponseWriter, r *http.Request) {
+			capturedOrderBy = r.URL.Query().Get("orderBy")
+			resp := map[string]interface{}{
+				"messages": []map[string]interface{}{
+					{"name": "spaces/AAAA/messages/msg2", "text": "Newer", "createTime": "2026-02-16T10:01:00Z"},
+					{"name": "spaces/AAAA/messages/msg1", "text": "Older", "createTime": "2026-02-16T10:00:00Z"},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	resp, err := svc.Spaces.Messages.List("spaces/AAAA").OrderBy("createTime DESC").PageSize(25).Do()
+	if err != nil {
+		t.Fatalf("failed to list messages: %v", err)
+	}
+
+	if capturedOrderBy != "createTime DESC" {
+		t.Errorf("expected orderBy 'createTime DESC', got '%s'", capturedOrderBy)
+	}
+	if resp.Messages[0].Text != "Newer" {
+		t.Errorf("expected first message 'Newer', got '%s'", resp.Messages[0].Text)
+	}
+}
+
+func TestChatMessages_WithFilter(t *testing.T) {
+	var capturedFilter string
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages": func(w http.ResponseWriter, r *http.Request) {
+			capturedFilter = r.URL.Query().Get("filter")
+			resp := map[string]interface{}{"messages": []map[string]interface{}{}}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	filterStr := `createTime > "2024-01-01T00:00:00Z"`
+	_, err = svc.Spaces.Messages.List("spaces/AAAA").Filter(filterStr).PageSize(25).Do()
+	if err != nil {
+		t.Fatalf("failed to list messages: %v", err)
+	}
+
+	if capturedFilter != filterStr {
+		t.Errorf("expected filter '%s', got '%s'", filterStr, capturedFilter)
+	}
+}
+
+func TestChatMessages_ShowDeleted(t *testing.T) {
+	var capturedShowDeleted string
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages": func(w http.ResponseWriter, r *http.Request) {
+			capturedShowDeleted = r.URL.Query().Get("showDeleted")
+			resp := map[string]interface{}{
+				"messages": []map[string]interface{}{
+					{
+						"name":       "spaces/AAAA/messages/msg1",
+						"text":       "",
+						"createTime": "2026-02-16T10:00:00Z",
+						"deleteTime": "2026-02-16T11:00:00Z",
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	resp, err := svc.Spaces.Messages.List("spaces/AAAA").ShowDeleted(true).PageSize(25).Do()
+	if err != nil {
+		t.Fatalf("failed to list messages: %v", err)
+	}
+
+	if capturedShowDeleted != "true" {
+		t.Errorf("expected showDeleted 'true', got '%s'", capturedShowDeleted)
+	}
+	if resp.Messages[0].DeleteTime != "2026-02-16T11:00:00Z" {
+		t.Errorf("expected deleteTime, got '%s'", resp.Messages[0].DeleteTime)
 	}
 }
 
@@ -244,6 +471,21 @@ func TestChatMembersCommand_Flags(t *testing.T) {
 	if maxFlag.DefValue != "100" {
 		t.Errorf("expected --max default '100', got '%s'", maxFlag.DefValue)
 	}
+	if membersCmd.Flags().Lookup("filter") == nil {
+		t.Error("expected --filter flag on members")
+	}
+	showGroups := membersCmd.Flags().Lookup("show-groups")
+	if showGroups == nil {
+		t.Error("expected --show-groups flag on members")
+	} else if showGroups.DefValue != "false" {
+		t.Errorf("expected --show-groups default 'false', got '%s'", showGroups.DefValue)
+	}
+	showInvited := membersCmd.Flags().Lookup("show-invited")
+	if showInvited == nil {
+		t.Error("expected --show-invited flag on members")
+	} else if showInvited.DefValue != "false" {
+		t.Errorf("expected --show-invited default 'false', got '%s'", showInvited.DefValue)
+	}
 }
 
 func TestChatMembers_MockServer(t *testing.T) {
@@ -301,6 +543,39 @@ func TestChatMembers_MockServer(t *testing.T) {
 	}
 	if resp.Memberships[2].Member.Type != "BOT" {
 		t.Errorf("expected third member type 'BOT', got '%s'", resp.Memberships[2].Member.Type)
+	}
+}
+
+func TestChatMembers_WithFilter(t *testing.T) {
+	var capturedFilter string
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/members": func(w http.ResponseWriter, r *http.Request) {
+			capturedFilter = r.URL.Query().Get("filter")
+			resp := map[string]interface{}{
+				"memberships": []map[string]interface{}{
+					{"name": "spaces/AAAA/members/111", "role": "ROLE_MEMBER", "member": map[string]interface{}{"displayName": "Alice", "name": "users/111", "type": "HUMAN"}},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	filterStr := `member.type = "HUMAN"`
+	_, err = svc.Spaces.Members.List("spaces/AAAA").Filter(filterStr).PageSize(100).Do()
+	if err != nil {
+		t.Fatalf("failed to list members: %v", err)
+	}
+
+	if capturedFilter != filterStr {
+		t.Errorf("expected filter '%s', got '%s'", filterStr, capturedFilter)
 	}
 }
 
@@ -483,5 +758,372 @@ func TestChatSend_MockServer(t *testing.T) {
 	}
 	if sent.Text != "Test message" {
 		t.Errorf("expected text 'Test message', got '%s'", sent.Text)
+	}
+}
+
+// --- New command tests ---
+
+func TestChatGetCommand_Flags(t *testing.T) {
+	getCmd := findSubcommand(chatCmd, "get")
+	if getCmd == nil {
+		t.Fatal("chat get command not found")
+	}
+	if getCmd.Args == nil {
+		t.Error("expected Args validator to be set")
+	}
+	if getCmd.Use != "get <message-name>" {
+		t.Errorf("unexpected Use: %s", getCmd.Use)
+	}
+}
+
+func TestChatGet_MockServer(t *testing.T) {
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages/msg1": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "GET" {
+				t.Errorf("expected GET, got %s", r.Method)
+			}
+			resp := map[string]interface{}{
+				"name":       "spaces/AAAA/messages/msg1",
+				"text":       "Hello world",
+				"createTime": "2026-02-16T10:00:00Z",
+				"sender":     map[string]interface{}{"displayName": "Alice", "type": "HUMAN", "name": "users/111"},
+				"thread":     map[string]interface{}{"name": "spaces/AAAA/threads/thread1"},
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	msg, err := svc.Spaces.Messages.Get("spaces/AAAA/messages/msg1").Do()
+	if err != nil {
+		t.Fatalf("failed to get message: %v", err)
+	}
+
+	if msg.Name != "spaces/AAAA/messages/msg1" {
+		t.Errorf("expected name 'spaces/AAAA/messages/msg1', got '%s'", msg.Name)
+	}
+	if msg.Text != "Hello world" {
+		t.Errorf("expected text 'Hello world', got '%s'", msg.Text)
+	}
+	if msg.Sender.DisplayName != "Alice" {
+		t.Errorf("expected sender 'Alice', got '%s'", msg.Sender.DisplayName)
+	}
+	if msg.Thread.Name != "spaces/AAAA/threads/thread1" {
+		t.Errorf("expected thread name, got '%s'", msg.Thread.Name)
+	}
+}
+
+func TestChatUpdateCommand_Flags(t *testing.T) {
+	updateCmd := findSubcommand(chatCmd, "update")
+	if updateCmd == nil {
+		t.Fatal("chat update command not found")
+	}
+	if updateCmd.Args == nil {
+		t.Error("expected Args validator to be set")
+	}
+	textFlag := updateCmd.Flags().Lookup("text")
+	if textFlag == nil {
+		t.Fatal("expected --text flag on update")
+	}
+}
+
+func TestChatUpdate_MockServer(t *testing.T) {
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages/msg1": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "PATCH" {
+				t.Errorf("expected PATCH, got %s", r.Method)
+			}
+
+			updateMask := r.URL.Query().Get("updateMask")
+			if updateMask != "text" {
+				t.Errorf("expected updateMask 'text', got '%s'", updateMask)
+			}
+
+			var msg chat.Message
+			json.NewDecoder(r.Body).Decode(&msg)
+
+			resp := &chat.Message{
+				Name:       "spaces/AAAA/messages/msg1",
+				Text:       msg.Text,
+				CreateTime: "2026-02-16T10:00:00Z",
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	msg := &chat.Message{Text: "Updated text"}
+	updated, err := svc.Spaces.Messages.Patch("spaces/AAAA/messages/msg1", msg).UpdateMask("text").Do()
+	if err != nil {
+		t.Fatalf("failed to update message: %v", err)
+	}
+
+	if updated.Text != "Updated text" {
+		t.Errorf("expected text 'Updated text', got '%s'", updated.Text)
+	}
+}
+
+func TestChatDeleteCommand_Flags(t *testing.T) {
+	deleteCmd := findSubcommand(chatCmd, "delete")
+	if deleteCmd == nil {
+		t.Fatal("chat delete command not found")
+	}
+	if deleteCmd.Args == nil {
+		t.Error("expected Args validator to be set")
+	}
+	forceFlag := deleteCmd.Flags().Lookup("force")
+	if forceFlag == nil {
+		t.Fatal("expected --force flag on delete")
+	}
+	if forceFlag.DefValue != "false" {
+		t.Errorf("expected --force default 'false', got '%s'", forceFlag.DefValue)
+	}
+}
+
+func TestChatDelete_MockServer(t *testing.T) {
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages/msg1": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "DELETE" {
+				t.Errorf("expected DELETE, got %s", r.Method)
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{})
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	_, err = svc.Spaces.Messages.Delete("spaces/AAAA/messages/msg1").Do()
+	if err != nil {
+		t.Fatalf("failed to delete message: %v", err)
+	}
+}
+
+func TestChatDelete_Force(t *testing.T) {
+	var capturedForce string
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages/msg1": func(w http.ResponseWriter, r *http.Request) {
+			capturedForce = r.URL.Query().Get("force")
+			json.NewEncoder(w).Encode(map[string]interface{}{})
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	_, err = svc.Spaces.Messages.Delete("spaces/AAAA/messages/msg1").Force(true).Do()
+	if err != nil {
+		t.Fatalf("failed to delete message: %v", err)
+	}
+
+	if capturedForce != "true" {
+		t.Errorf("expected force 'true', got '%s'", capturedForce)
+	}
+}
+
+func TestChatReactionsCommand_Flags(t *testing.T) {
+	reactionsCmd := findSubcommand(chatCmd, "reactions")
+	if reactionsCmd == nil {
+		t.Fatal("chat reactions command not found")
+	}
+	if reactionsCmd.Args == nil {
+		t.Error("expected Args validator to be set")
+	}
+	if reactionsCmd.Flags().Lookup("filter") == nil {
+		t.Error("expected --filter flag on reactions")
+	}
+	pageSizeFlag := reactionsCmd.Flags().Lookup("page-size")
+	if pageSizeFlag == nil {
+		t.Fatal("expected --page-size flag on reactions")
+	}
+	if pageSizeFlag.DefValue != "25" {
+		t.Errorf("expected --page-size default '25', got '%s'", pageSizeFlag.DefValue)
+	}
+}
+
+func TestChatReactions_MockServer(t *testing.T) {
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages/msg1/reactions": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "GET" {
+				t.Errorf("expected GET, got %s", r.Method)
+			}
+			resp := map[string]interface{}{
+				"reactions": []map[string]interface{}{
+					{
+						"name":  "spaces/AAAA/messages/msg1/reactions/rxn1",
+						"emoji": map[string]interface{}{"unicode": "\U0001f44d"},
+						"user":  map[string]interface{}{"displayName": "Alice", "name": "users/111"},
+					},
+					{
+						"name":  "spaces/AAAA/messages/msg1/reactions/rxn2",
+						"emoji": map[string]interface{}{"unicode": "\u2764\ufe0f"},
+						"user":  map[string]interface{}{"displayName": "Bob", "name": "users/222"},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	resp, err := svc.Spaces.Messages.Reactions.List("spaces/AAAA/messages/msg1").PageSize(25).Do()
+	if err != nil {
+		t.Fatalf("failed to list reactions: %v", err)
+	}
+
+	if len(resp.Reactions) != 2 {
+		t.Fatalf("expected 2 reactions, got %d", len(resp.Reactions))
+	}
+	if resp.Reactions[0].Emoji.Unicode != "\U0001f44d" {
+		t.Errorf("expected thumbs up emoji, got '%s'", resp.Reactions[0].Emoji.Unicode)
+	}
+	if resp.Reactions[1].User.DisplayName != "Bob" {
+		t.Errorf("expected user 'Bob', got '%s'", resp.Reactions[1].User.DisplayName)
+	}
+}
+
+func TestChatReactCommand_Flags(t *testing.T) {
+	reactCmd := findSubcommand(chatCmd, "react")
+	if reactCmd == nil {
+		t.Fatal("chat react command not found")
+	}
+	if reactCmd.Args == nil {
+		t.Error("expected Args validator to be set")
+	}
+	emojiFlag := reactCmd.Flags().Lookup("emoji")
+	if emojiFlag == nil {
+		t.Fatal("expected --emoji flag on react")
+	}
+}
+
+func TestChatReact_MockServer(t *testing.T) {
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages/msg1/reactions": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "POST" {
+				t.Errorf("expected POST, got %s", r.Method)
+			}
+
+			var reaction chat.Reaction
+			json.NewDecoder(r.Body).Decode(&reaction)
+
+			if reaction.Emoji == nil || reaction.Emoji.Unicode != "\U0001f600" {
+				t.Errorf("expected emoji unicode '😀', got %+v", reaction.Emoji)
+			}
+
+			resp := &chat.Reaction{
+				Name:  "spaces/AAAA/messages/msg1/reactions/rxn-new",
+				Emoji: reaction.Emoji,
+			}
+			json.NewEncoder(w).Encode(resp)
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	reaction := &chat.Reaction{
+		Emoji: &chat.Emoji{Unicode: "\U0001f600"},
+	}
+	created, err := svc.Spaces.Messages.Reactions.Create("spaces/AAAA/messages/msg1", reaction).Do()
+	if err != nil {
+		t.Fatalf("failed to create reaction: %v", err)
+	}
+
+	if created.Name != "spaces/AAAA/messages/msg1/reactions/rxn-new" {
+		t.Errorf("expected reaction name, got '%s'", created.Name)
+	}
+}
+
+func TestChatUnreactCommand_Flags(t *testing.T) {
+	unreactCmd := findSubcommand(chatCmd, "unreact")
+	if unreactCmd == nil {
+		t.Fatal("chat unreact command not found")
+	}
+	if unreactCmd.Args == nil {
+		t.Error("expected Args validator to be set")
+	}
+	if unreactCmd.Use != "unreact <reaction-name>" {
+		t.Errorf("unexpected Use: %s", unreactCmd.Use)
+	}
+}
+
+func TestChatUnreact_MockServer(t *testing.T) {
+	handlers := map[string]func(w http.ResponseWriter, r *http.Request){
+		"/v1/spaces/AAAA/messages/msg1/reactions/rxn1": func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "DELETE" {
+				t.Errorf("expected DELETE, got %s", r.Method)
+			}
+			json.NewEncoder(w).Encode(map[string]interface{}{})
+		},
+	}
+
+	server := mockChatServer(t, handlers)
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	_, err = svc.Spaces.Messages.Reactions.Delete("spaces/AAAA/messages/msg1/reactions/rxn1").Do()
+	if err != nil {
+		t.Fatalf("failed to delete reaction: %v", err)
+	}
+}
+
+func TestEnsureSpaceName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"AAAA", "spaces/AAAA"},
+		{"spaces/AAAA", "spaces/AAAA"},
+		{"spaces/BBBB", "spaces/BBBB"},
+		{"CCCC", "spaces/CCCC"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ensureSpaceName(tt.input)
+			if result != tt.expected {
+				t.Errorf("ensureSpaceName(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
 	}
 }

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -396,6 +396,13 @@ func TestChatCommands(t *testing.T) {
 		{"list"},
 		{"messages"},
 		{"send"},
+		{"members"},
+		{"get"},
+		{"update"},
+		{"delete"},
+		{"reactions"},
+		{"react"},
+		{"unreact"},
 	}
 
 	for _, tt := range tests {

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -13,7 +13,7 @@ var ServiceScopes = map[string][]string{
 	"sheets":   {"spreadsheets"},
 	"slides":   {"presentations.readonly", "presentations"},
 	"tasks":    {"tasks.readonly", "tasks"},
-	"chat":     {"chat.spaces.readonly", "chat.messages", "chat.messages.create", "chat.memberships.readonly"},
+	"chat":     {"chat.spaces.readonly", "chat.messages", "chat.messages.create", "chat.memberships.readonly", "chat.messages.reactions", "chat.messages.reactions.create"},
 	"forms":    {"forms.responses.readonly"},
 	"contacts": {"contacts.readonly", "contacts"},
 	"userinfo": {"userinfo.email"},

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gws-chat
-version: 1.2.0
-description: "Google Chat CLI operations via gws. Use when users need to list chat spaces, read messages, or send messages in Google Chat. Triggers: google chat, gchat, chat spaces, chat messages."
+version: 1.3.0
+description: "Google Chat CLI operations via gws. Use when users need to list chat spaces, read messages, send/update/delete messages, or manage reactions in Google Chat. Triggers: google chat, gchat, chat spaces, chat messages."
 metadata:
   short-description: Google Chat CLI operations
   compatibility: claude-code, codex-cli
@@ -38,20 +38,31 @@ For initial setup, see the `gws-auth` skill.
 | Task | Command |
 |------|---------|
 | List chat spaces | `gws chat list` |
+| List spaces (filtered) | `gws chat list --filter 'spaceType = "SPACE"'` |
 | Read messages | `gws chat messages <space-id>` |
-| Read recent messages | `gws chat messages <space-id> --max 10` |
+| Read recent messages (ordered) | `gws chat messages <space-id> --order-by "createTime DESC" --max 10` |
 | List space members | `gws chat members <space-id>` |
 | Send a message | `gws chat send --space <space-id> --text "Hello"` |
+| Get a single message | `gws chat get <message-name>` |
+| Update a message | `gws chat update <message-name> --text "New text"` |
+| Delete a message | `gws chat delete <message-name>` |
+| List reactions | `gws chat reactions <message-name>` |
+| Add a reaction | `gws chat react <message-name> --emoji "👍"` |
+| Remove a reaction | `gws chat unreact <reaction-name>` |
 
 ## Detailed Usage
 
 ### list — List chat spaces
 
 ```bash
-gws chat list
+gws chat list [flags]
 ```
 
-Lists all Chat spaces (rooms, DMs, group chats) you have access to.
+Lists all Chat spaces (rooms, DMs, group chats) you have access to. Supports filtering and pagination.
+
+**Flags:**
+- `--filter string` — Filter spaces (e.g. `spaceType = "SPACE"`)
+- `--page-size int` — Number of spaces per page (default 100)
 
 ### messages — List messages in a space
 
@@ -61,6 +72,9 @@ gws chat messages <space-id> [flags]
 
 **Flags:**
 - `--max int` — Maximum number of messages to return (default 25)
+- `--filter string` — Filter messages (e.g. `createTime > "2024-01-01T00:00:00Z"`)
+- `--order-by string` — Order messages (e.g. `createTime DESC`)
+- `--show-deleted` — Include deleted messages in results
 
 ### members — List space members
 
@@ -74,6 +88,9 @@ Display names and emails are auto-resolved via the People API and cached locally
 
 **Flags:**
 - `--max int` — Maximum number of members to return (default 100)
+- `--filter string` — Filter members (e.g. `member.type = "HUMAN"`)
+- `--show-groups` — Include Google Group memberships
+- `--show-invited` — Include invited memberships
 
 **Output includes:**
 - `display_name` — Member's display name (resolved via People API)
@@ -86,17 +103,65 @@ Display names and emails are auto-resolved via the People API and cached locally
 ### send — Send a message
 
 ```bash
-gws chat send --space <space-id> --text <message> [flags]
+gws chat send --space <space-id> --text <message>
 ```
 
 **Flags:**
 - `--space string` — Space ID or name (required)
 - `--text string` — Message text (required)
 
-**Examples:**
+### get — Get a single message
+
 ```bash
-gws chat send --space spaces/AAAA1234 --text "Hello team!"
+gws chat get <message-name>
 ```
+
+Retrieves a single message by its resource name (e.g. `spaces/AAAA/messages/msg1`).
+
+### update — Update a message
+
+```bash
+gws chat update <message-name> --text "New text"
+```
+
+**Flags:**
+- `--text string` — New message text (required)
+
+### delete — Delete a message
+
+```bash
+gws chat delete <message-name> [flags]
+```
+
+**Flags:**
+- `--force` — Force delete even if message has replies
+
+### reactions — List reactions on a message
+
+```bash
+gws chat reactions <message-name> [flags]
+```
+
+**Flags:**
+- `--filter string` — Filter reactions (e.g. `emoji.unicode = "😀"`)
+- `--page-size int` — Number of reactions per page (default 25)
+
+### react — Add a reaction
+
+```bash
+gws chat react <message-name> --emoji "👍"
+```
+
+**Flags:**
+- `--emoji string` — Emoji unicode character (required)
+
+### unreact — Remove a reaction
+
+```bash
+gws chat unreact <reaction-name>
+```
+
+Removes a reaction by its resource name (e.g. `spaces/AAAA/messages/msg1/reactions/rxn1`).
 
 ## Output Modes
 
@@ -111,5 +176,7 @@ gws chat list --format text    # Human-readable text
 - Always use `--format json` (the default) for programmatic parsing
 - Use `gws chat list` first to get space IDs
 - Space IDs are in the format `spaces/AAAA1234`
+- Message names are in the format `spaces/AAAA/messages/msg1`
 - `members` auto-resolves display names via People API — first call may be slower, subsequent calls use cache
+- Use `--order-by "createTime DESC"` with messages to get newest first
 - Chat API requires additional GCP setup beyond standard OAuth — see the `gws-auth` skill

--- a/skills/chat/references/commands.md
+++ b/skills/chat/references/commands.md
@@ -24,13 +24,16 @@ Google Chat API requires additional setup beyond standard OAuth:
 
 ## gws chat list
 
-Lists all Chat spaces (rooms, DMs, group chats) you have access to.
+Lists all Chat spaces (rooms, DMs, group chats) you have access to. Supports filtering and pagination.
 
 ```
-Usage: gws chat list
+Usage: gws chat list [flags]
 ```
 
-No additional flags.
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--filter` | string | | Filter spaces (e.g. `spaceType = "SPACE"`) |
+| `--page-size` | int | 100 | Number of spaces per page |
 
 ### Output Fields (JSON)
 
@@ -43,7 +46,7 @@ Each space includes:
 
 ## gws chat messages
 
-Lists recent messages in a Chat space.
+Lists recent messages in a Chat space. Supports filtering, ordering, pagination, and showing deleted messages.
 
 ```
 Usage: gws chat messages <space-id> [flags]
@@ -52,6 +55,9 @@ Usage: gws chat messages <space-id> [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--max` | int | 25 | Maximum number of messages to return |
+| `--filter` | string | | Filter messages (e.g. `createTime > "2024-01-01T00:00:00Z"`) |
+| `--order-by` | string | | Order messages (e.g. `createTime DESC`) |
+| `--show-deleted` | bool | false | Include deleted messages in results |
 
 The space ID format is `spaces/AAAA1234` (get from `gws chat list`).
 
@@ -68,6 +74,9 @@ Usage: gws chat members <space-id> [flags]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--max` | int | 100 | Maximum number of members to return |
+| `--filter` | string | | Filter members (e.g. `member.type = "HUMAN"`) |
+| `--show-groups` | bool | false | Include Google Group memberships |
+| `--show-invited` | bool | false | Include invited memberships |
 
 The space ID format is `spaces/AAAA1234` (get from `gws chat list`).
 
@@ -102,3 +111,100 @@ Usage: gws chat send [flags]
 |------|------|---------|----------|-------------|
 | `--space` | string | | Yes | Space ID or name |
 | `--text` | string | | Yes | Message text |
+
+---
+
+## gws chat get
+
+Retrieves a single message by its resource name.
+
+```
+Usage: gws chat get <message-name>
+```
+
+The message name format is `spaces/AAAA/messages/msg1` (get from `gws chat messages`).
+
+### Output Fields (JSON)
+
+- `name` — Message resource name
+- `text` — Message text content
+- `create_time` — Message creation timestamp
+- `sender` — Sender display name (falls back to resource name)
+- `sender_type` — `HUMAN` or `BOT`
+- `thread` — Thread resource name (if part of a thread)
+
+---
+
+## gws chat update
+
+Updates the text of an existing message.
+
+```
+Usage: gws chat update <message-name> [flags]
+```
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--text` | string | | Yes | New message text |
+
+---
+
+## gws chat delete
+
+Deletes a message by its resource name.
+
+```
+Usage: gws chat delete <message-name> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--force` | bool | false | Force delete even if message has replies |
+
+---
+
+## gws chat reactions
+
+Lists all reactions on a message.
+
+```
+Usage: gws chat reactions <message-name> [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--filter` | string | | Filter reactions (e.g. `emoji.unicode = "😀"`) |
+| `--page-size` | int | 25 | Number of reactions per page |
+
+### Output Fields (JSON)
+
+Each reaction includes:
+- `name` — Reaction resource name
+- `emoji` — Emoji unicode character
+- `user` — User display name who reacted
+
+---
+
+## gws chat react
+
+Adds an emoji reaction to a message.
+
+```
+Usage: gws chat react <message-name> [flags]
+```
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--emoji` | string | | Yes | Emoji unicode character (e.g. `😀`) |
+
+---
+
+## gws chat unreact
+
+Removes a reaction by its resource name.
+
+```
+Usage: gws chat unreact <reaction-name>
+```
+
+The reaction name format is `spaces/AAAA/messages/msg1/reactions/rxn1` (get from `gws chat reactions`).


### PR DESCRIPTION
## Summary
- **New flags on existing commands:** `--filter`, `--page-size` on `list`; `--filter`, `--order-by`, `--show-deleted` on `messages`; `--filter`, `--show-groups`, `--show-invited` on `members`
- **Pagination:** `list` and `messages` now paginate (NextPageToken loop), matching the gmail pattern
- **6 new commands:** `get`, `update`, `delete`, `reactions`, `react`, `unreact` — full message CRUD and emoji reactions
- **Scopes:** Added `chat.messages.reactions` and `chat.messages.reactions.create`
- **Version bump:** v1.18.1 → v1.19.0

## Test plan
- [x] All existing chat tests pass unchanged
- [x] New flag tests: verify --filter, --order-by, --show-deleted, --show-groups, --show-invited, --emoji, --force, --page-size defaults
- [x] New mock server tests: get, update (verifies updateMask=text), delete, delete --force, reactions list, react (POST with emoji), unreact (DELETE)
- [x] Pagination tests: list pagination (2 pages), members pagination stops at --max
- [x] `TestChatCommands` updated with all 10 subcommands (was missing `members` + 6 new)
- [x] `ensureSpaceName` helper tested for prefix normalization
- [x] `go vet ./...` clean, `go test ./...` all pass, `make build` compiles

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)