### PR TITLE
fix(slides): snake_case output keys, explicit file close, validate size early

### DIFF
--- a/cmd/slides.go
+++ b/cmd/slides.go
@@ -3165,21 +3165,24 @@ func runSlidesThumbnail(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return p.PrintError(fmt.Errorf("failed to download thumbnail: %w", err))
 		}
-		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
 			return p.PrintError(fmt.Errorf("failed to download thumbnail: HTTP %d", resp.StatusCode))
 		}
 
 		f, err := os.Create(downloadPath)
 		if err != nil {
+			resp.Body.Close()
 			return p.PrintError(fmt.Errorf("failed to create file: %w", err))
 		}
 
 		if _, err := io.Copy(f, resp.Body); err != nil {
 			f.Close()
+			resp.Body.Close()
 			return p.PrintError(fmt.Errorf("failed to write thumbnail file: %w", err))
 		}
+		resp.Body.Close()
 
 		if err := f.Close(); err != nil {
 			return p.PrintError(fmt.Errorf("failed to finalize thumbnail file: %w", err))


### PR DESCRIPTION
## Summary
Post-merge review fixes for PR #107 (slides thumbnails). Addresses issues found by both PR-reviewer and Codex:

- **snake_case output keys**: Rename `contentUrl` → `content_url` and `savedTo` → `saved_to` to match the project's snake_case convention used by all other commands.
- **Explicit file close**: Replace `defer f.Close()` with explicit `f.Close()` + error check, ensuring file flush errors are surfaced to the caller.
- **Validate size early**: Move size validation before the `Presentations.Get` API call to avoid an unnecessary round-trip when the size is invalid.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [ ] Manual test: `gws slides thumbnail <id> --slide 1 --download thumb.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)