### PR TITLE
fix(sheets): PIE chart domain/series, --value validation, negative index guard

### DIFF
--- a/cmd/sheets.go
+++ b/cmd/sheets.go
@@ -2613,6 +2613,9 @@ func runSheetsAddChart(cmd *cobra.Command, args []string) error {
 
 	if chartType == "PIE" {
 		// PIE: first column = labels (domain), remaining columns = data (series)
+		if gridRange.EndColumnIndex-gridRange.StartColumnIndex < 2 {
+			return p.PrintError(fmt.Errorf("PIE chart requires at least 2 columns (labels + data), got range with %d column(s)", gridRange.EndColumnIndex-gridRange.StartColumnIndex))
+		}
 		domainRange := &sheets.GridRange{
 			SheetId:          gridRange.SheetId,
 			StartRowIndex:    gridRange.StartRowIndex,


### PR DESCRIPTION
## Summary
Post-merge review fixes for PR #127 (sheets charts/conditional formatting). Addresses issues found by both PR-reviewer and Codex:

- **PIE chart domain/series**: Split data range into separate domain (first column = labels) and series (remaining columns = data) instead of passing the same full range for both, which produced semantically incorrect chart data.
- **--value validation**: Validate that `--value` is provided for conditional format rule types that require it (`>`, `<`, `=`, `!=`, `contains`, `not-contains`, `formula`). Previously an empty value was silently sent to the API.
- **Negative index guard**: Reject negative `--index` values in `delete-conditional-format` before making the API call.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [ ] Manual test: `gws sheets add-chart <id> --type PIE --data "Sheet1!A1:B5"` produces correct chart
- [ ] Manual test: `gws sheets add-conditional-format <id> "A1:A10" --rule ">" ` without --value shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)