### PR TITLE
docs(chat): common mistakes and group chat recipe

### DIFF
--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -366,13 +366,13 @@ When you know the participants but not the space ID:
 
 ```bash
 # 1. List all spaces, filter to group chats, sort by recent activity
-gws chat list --format json | jq '[.[] | select(.type == "GROUP_CHAT")] | sort_by(.last_active_time) | reverse | .[:10]'
+gws chat list --format json | jq '.spaces | map(select(.type == "GROUP_CHAT")) | sort_by(.last_active_time // "") | reverse | .[:10]'
 
 # 2. Check members of candidate spaces
-gws chat members spaces/AAAApznBCFA --format text
+gws chat members spaces/AAAApznBCFA --format json
 
 # 3. Once found, get recent messages with a time filter
-gws chat messages spaces/AAAApznBCFA --filter 'createTime > "2026-02-20T00:00:00Z"' --max 25
+gws chat messages spaces/AAAApznBCFA --filter 'createTime > "2026-02-20T00:00:00Z"' --order-by "createTime DESC" --max 25
 ```
 
 **Key insight**: DMs and group chats often have empty `display_name` — you must check `members` to identify participants.


### PR DESCRIPTION
## Summary
- Added **Common Mistakes** table: `--limit` vs `--max`, `find-dm` user format
- Added **Recipe: Find a Group Chat by Member Names**: step-by-step pattern for locating group chats when you only know participant names
- Added `createTime` filter tip to AI Agents section
- Version bump: 2.0.0 → 2.1.0

## Context
From a `/reflect` session after using `gws chat` to find a 3-person group chat and read recent messages. Two errors were hit (`--limit` flag, `find-dm` email format) that are now documented.

## Test plan
- [ ] Verify SKILL.md renders correctly in GitHub
- [ ] Confirm no broken markdown formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)