### PR TITLE
Add --attachment flag to gmail send and create-draft

### DIFF
--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -50,7 +50,7 @@ var gmailSendCmd = &cobra.Command{
 Examples:
   gws gmail send --to user@example.com --subject "Hello" --body "Hi there"
   gws gmail send --to user@example.com --subject "Report" --body "See attached" --attachment "/tmp/report.pdf"
-  gws gmail send --to user@example.com --subject "Files" --body "Multiple files" --attachment "/tmp/a.pdf,/tmp/b.png"`,
+  gws gmail send --to user@example.com --subject "Files" --body "Multiple files" --attachment /tmp/a.pdf --attachment /tmp/b.png`,
 	RunE: runGmailSend,
 }
 
@@ -322,7 +322,7 @@ func init() {
 	gmailSendCmd.Flags().String("bcc", "", "BCC recipients (comma-separated)")
 	gmailSendCmd.Flags().String("thread-id", "", "Thread ID to reply in")
 	gmailSendCmd.Flags().String("reply-to-message-id", "", "Message ID to reply to (sets In-Reply-To/References headers)")
-	gmailSendCmd.Flags().String("attachment", "", "File paths to attach (comma-separated)")
+	gmailSendCmd.Flags().StringArray("attachment", nil, "File path to attach (repeatable: --attachment a.pdf --attachment b.pdf)")
 	gmailSendCmd.MarkFlagRequired("to")
 	gmailSendCmd.MarkFlagRequired("subject")
 	gmailSendCmd.MarkFlagRequired("body")
@@ -404,7 +404,7 @@ func init() {
 	gmailCreateDraftCmd.Flags().String("cc", "", "CC recipients (comma-separated)")
 	gmailCreateDraftCmd.Flags().String("bcc", "", "BCC recipients (comma-separated)")
 	gmailCreateDraftCmd.Flags().String("thread-id", "", "Thread ID for reply draft")
-	gmailCreateDraftCmd.Flags().String("attachment", "", "File paths to attach (comma-separated)")
+	gmailCreateDraftCmd.Flags().StringArray("attachment", nil, "File path to attach (repeatable: --attachment a.pdf --attachment b.pdf)")
 	gmailCreateDraftCmd.MarkFlagRequired("to")
 
 	// Update draft flags
@@ -693,6 +693,16 @@ func buildMIMEMessage(headers map[string]string, body string, attachmentPaths []
 			continue
 		}
 
+		// Check file size before reading (Gmail API limit is 25MB for the whole message).
+		info, err := os.Stat(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to stat attachment %q: %w", filePath, err)
+		}
+		const maxAttachmentSize = 25 * 1024 * 1024 // 25 MB
+		if info.Size() > maxAttachmentSize {
+			return nil, fmt.Errorf("attachment %q is %d bytes, exceeds 25 MB limit", filePath, info.Size())
+		}
+
 		data, err := os.ReadFile(filePath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read attachment %q: %w", filePath, err)
@@ -713,9 +723,12 @@ func buildMIMEMessage(headers map[string]string, body string, attachmentPaths []
 			return r
 		}, filename)
 
+		// Encode non-ASCII filenames per RFC 2047.
+		encodedFilename := mime.BEncoding.Encode("UTF-8", safeFilename)
+
 		buf.WriteString(fmt.Sprintf("--%s\r\n", boundary))
-		buf.WriteString(fmt.Sprintf("Content-Type: %s; name=\"%s\"\r\n", contentType, safeFilename))
-		buf.WriteString(fmt.Sprintf("Content-Disposition: attachment; filename=\"%s\"\r\n", safeFilename))
+		buf.WriteString(fmt.Sprintf("Content-Type: %s; name=\"%s\"\r\n", contentType, encodedFilename))
+		buf.WriteString(fmt.Sprintf("Content-Disposition: attachment; filename=\"%s\"\r\n", encodedFilename))
 		buf.WriteString("Content-Transfer-Encoding: base64\r\n")
 		buf.WriteString("\r\n")
 
@@ -781,11 +794,7 @@ func runGmailSend(cmd *cobra.Command, args []string) error {
 	}
 
 	// Parse attachment paths
-	attachmentStr, _ := cmd.Flags().GetString("attachment")
-	var attachmentPaths []string
-	if attachmentStr != "" {
-		attachmentPaths = strings.Split(attachmentStr, ",")
-	}
+	attachmentPaths, _ := cmd.Flags().GetStringArray("attachment")
 
 	// Build RFC 2822 message
 	msgHeaders := map[string]string{
@@ -1902,11 +1911,7 @@ func runGmailCreateDraft(cmd *cobra.Command, args []string) error {
 	threadID, _ := cmd.Flags().GetString("thread-id")
 
 	// Parse attachment paths
-	attachmentStr, _ := cmd.Flags().GetString("attachment")
-	var attachmentPaths []string
-	if attachmentStr != "" {
-		attachmentPaths = strings.Split(attachmentStr, ",")
-	}
+	attachmentPaths, _ := cmd.Flags().GetStringArray("attachment")
 
 	// Build RFC 2822 message
 	msgHeaders := map[string]string{

--- a/cmd/gmail_test.go
+++ b/cmd/gmail_test.go
@@ -2517,7 +2517,7 @@ func TestBuildMIMEMessage(t *testing.T) {
 		if err == nil {
 			t.Error("expected error for missing file")
 		}
-		if !strings.Contains(err.Error(), "failed to read attachment") {
+		if !strings.Contains(err.Error(), "failed to stat attachment") {
 			t.Errorf("unexpected error message: %v", err)
 		}
 	})

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -125,13 +125,14 @@ gws gmail send --to <email> --subject <subject> --body <body> [flags]
 - `--body string` — Email body (required)
 - `--cc string` — CC recipients (comma-separated)
 - `--bcc string` — BCC recipients (comma-separated)
-- `--attachment string` — File paths to attach (comma-separated)
+- `--attachment string` — File path to attach (repeatable)
 
 **Examples:**
 ```bash
 gws gmail send --to user@example.com --subject "Meeting" --body "Let's meet at 3pm"
 gws gmail send --to user@example.com --cc team@example.com --subject "Update" --body "Status update"
-gws gmail send --to user@example.com --subject "Report" --body "See attached" --attachment "/tmp/report.pdf"
+gws gmail send --to user@example.com --subject "Report" --body "See attached" --attachment /tmp/report.pdf
+gws gmail send --to user@example.com --subject "Files" --body "Multiple" --attachment /tmp/a.pdf --attachment /tmp/b.png
 ```
 
 ### labels — List all labels
@@ -380,13 +381,13 @@ gws gmail create-draft --to <email> [flags]
 - `--cc string` — CC recipients (comma-separated)
 - `--bcc string` — BCC recipients (comma-separated)
 - `--thread-id string` — Thread ID for reply draft
-- `--attachment string` — File paths to attach (comma-separated)
+- `--attachment string` — File path to attach (repeatable)
 
 **Examples:**
 ```bash
 gws gmail create-draft --to user@example.com --subject "Draft" --body "Work in progress"
 gws gmail create-draft --to user@example.com --subject "Re: Topic" --thread-id thread123
-gws gmail create-draft --to user@example.com --subject "Draft" --body "See attached" --attachment "/tmp/file.pdf"
+gws gmail create-draft --to user@example.com --subject "Draft" --body "See attached" --attachment /tmp/file.pdf
 ```
 
 ### update-draft — Update a draft

--- a/skills/gmail/references/commands.md
+++ b/skills/gmail/references/commands.md
@@ -122,7 +122,7 @@ Usage: gws gmail send [flags]
 | `--bcc` | string | | No | BCC recipients (comma-separated) |
 | `--thread-id` | string | | No | Thread ID to reply in |
 | `--reply-to-message-id` | string | | No | Message ID to reply to (sets In-Reply-To/References headers) |
-| `--attachment` | string | | No | File paths to attach (comma-separated) |
+| `--attachment` | stringArray | | No | File path to attach (repeatable) |
 
 ---
 
@@ -487,7 +487,7 @@ Usage: gws gmail create-draft [flags]
 | `--cc` | string | | No | CC recipients (comma-separated) |
 | `--bcc` | string | | No | BCC recipients (comma-separated) |
 | `--thread-id` | string | | No | Thread ID for reply draft |
-| `--attachment` | string | | No | File paths to attach (comma-separated) |
+| `--attachment` | stringArray | | No | File path to attach (repeatable) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a new `--attachment` flag (comma-separated file paths) to `gmail send` and `gmail create-draft` commands
- Builds proper MIME multipart/mixed messages with base64-encoded file attachments and auto-detected Content-Type (via `mime.TypeByExtension`)
- Fully backward compatible: when `--attachment` is not provided, message construction is identical to the previous simple text/plain behavior

## Usage examples

```bash
# Send with a single attachment
gws gmail send --to user@example.com --subject "Report" --body "See attached" \
  --attachment "/tmp/report.pdf"

# Send with multiple attachments
gws gmail send --to user@example.com --subject "Files" --body "Multiple files" \
  --attachment "/tmp/report.pdf,/tmp/chart.png"

# Create a draft with an attachment
gws gmail create-draft --to user@example.com --subject "Draft" --body "WIP" \
  --attachment "/tmp/notes.txt"
```

## Implementation details

- New `buildMIMEMessage()` helper constructs either a simple text/plain message (no attachments) or a multipart/mixed MIME message (with attachments)
- Uses `crypto/rand` for unique MIME boundary generation
- Base64 content is line-wrapped at 76 characters per RFC 2045
- Only stdlib packages are used (no new dependencies)

## Test plan

- [ ] Verify `gmail send` without `--attachment` works identically to before
- [ ] Verify `gmail send --attachment "/path/to/file.pdf"` sends email with attachment
- [ ] Verify `gmail send --attachment "/path/a.pdf,/path/b.png"` sends with multiple attachments
- [ ] Verify `gmail create-draft --attachment "/path/to/file.pdf"` creates draft with attachment
- [ ] Verify error is returned for non-existent attachment file paths
- [ ] `go build ./...` and `go vet ./...` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)