### PR TITLE
v1.36.0 core: chat attachments, calendar self-attendee, chat find-space (#171, #176, #170)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 **/CLAUDE.md
 !/CLAUDE.md
 
+# AMQ squad coordination state
+.agent-mail/
+.amq-squad/
+
 # OS
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Add `--format text` for human-readable output, or `--format yaml` for YAML.
 | `gws chat event <event>` | Get event details |
 | `gws chat build-cache` | Build space-members cache (`--type`) |
 | `gws chat find-group` | Find group chats by member emails (`--members`, `--refresh`) |
+| `gws chat find-space` | Find spaces by display name substring (`--name`, `--type`, `--refresh`) |
 
 ### Forms
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Add `--format text` for human-readable output, or `--format yaml` for YAML.
 |---------|-------------|
 | `gws calendar list` | List all calendars |
 | `gws calendar events` | List events (`--days`, `--from`, `--calendar-id`, `--max`, `--pending`, `--query`, `--event-types`, `--show-deleted`, `--timezone`, `--updated-min`) |
-| `gws calendar create` | Create event (`--title`, `--start`, `--end`, `--attendees`) |
+| `gws calendar create` | Create event (`--title`, `--start`, `--end`, `--attendees`, `--add-self`) |
 | `gws calendar update <id>` | Update event (`--title`, `--start`, `--end`, `--add-attendees`) |
 | `gws calendar delete <id>` | Delete event |
 | `gws calendar rsvp <id>` | RSVP to invite (`--response accepted/declined/tentative`, `--message`) |

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -364,6 +364,7 @@ func init() {
 	calendarCreateCmd.Flags().String("description", "", "Event description")
 	calendarCreateCmd.Flags().String("location", "", "Event location")
 	calendarCreateCmd.Flags().StringSlice("attendees", nil, "Attendee email addresses")
+	calendarCreateCmd.Flags().Bool("add-self", true, "Add the authenticated user as an accepted attendee (use --add-self=false to opt out)")
 	calendarCreateCmd.MarkFlagRequired("title")
 	calendarCreateCmd.MarkFlagRequired("start")
 	calendarCreateCmd.MarkFlagRequired("end")
@@ -632,6 +633,7 @@ func runCalendarCreate(cmd *cobra.Command, args []string) error {
 	description, _ := cmd.Flags().GetString("description")
 	location, _ := cmd.Flags().GetString("location")
 	attendees, _ := cmd.Flags().GetStringSlice("attendees")
+	addSelf, _ := cmd.Flags().GetBool("add-self")
 
 	// Parse times
 	startTime, err := parseTime(startStr)
@@ -667,6 +669,24 @@ func runCalendarCreate(cmd *cobra.Command, args []string) error {
 			eventAttendees[i] = &calendar.EventAttendee{Email: email}
 		}
 		event.Attendees = eventAttendees
+	}
+
+	// Add the authenticated user as an accepted attendee unless --no-add-self is set.
+	// The Calendar API does not auto-include the organizer in attendees, so downstream
+	// consumers checking attendees[].self/email get a missing entry for events you
+	// created. Mirrors the Calendar UI which always shows the organizer as attending.
+	if addSelf {
+		selfEmail, lookupErr := getSelfCalendarEmail(svc)
+		if lookupErr != nil {
+			return p.PrintError(fmt.Errorf("failed to resolve self email for --add-self: %w (pass --no-add-self to skip)", lookupErr))
+		}
+		if !attendeeListContainsEmail(event.Attendees, selfEmail) {
+			event.Attendees = append(event.Attendees, &calendar.EventAttendee{
+				Email:          selfEmail,
+				ResponseStatus: "accepted",
+				Self:           true,
+			})
+		}
 	}
 
 	created, err := svc.Events.Insert(calendarID, event).Do()
@@ -1940,6 +1960,39 @@ func parseTime(s string) (time.Time, error) {
 	}
 
 	return time.Time{}, fmt.Errorf("unrecognized time format: %s (use RFC3339 or 'YYYY-MM-DD HH:MM')", s)
+}
+
+// getSelfCalendarEmail returns the authenticated user's primary calendar address,
+// which is also their account email. Used by --add-self to populate the attendees
+// list with the organizer.
+func getSelfCalendarEmail(svc *calendar.Service) (string, error) {
+	cal, err := svc.Calendars.Get("primary").Do()
+	if err != nil {
+		return "", err
+	}
+	if cal == nil || cal.Id == "" {
+		return "", fmt.Errorf("primary calendar returned empty id")
+	}
+	return cal.Id, nil
+}
+
+// attendeeListContainsEmail reports whether the attendees slice already includes
+// the given email (case-insensitive). Used to avoid duplicating the organizer
+// when the user passed themselves in --attendees explicitly.
+func attendeeListContainsEmail(atts []*calendar.EventAttendee, email string) bool {
+	if email == "" {
+		return false
+	}
+	target := strings.ToLower(email)
+	for _, a := range atts {
+		if a == nil {
+			continue
+		}
+		if strings.ToLower(a.Email) == target {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveIANA returns the IANA timezone name for a time.Time.

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -686,12 +686,19 @@ func runCalendarCreate(cmd *cobra.Command, args []string) error {
 	// created. Mirrors the Calendar UI which always shows the organizer as attending.
 	// Note: attendees[].self is read-only; we set Email + ResponseStatus only and let
 	// the API populate self on the returned event.
+	//
+	// On the default path (user didn't explicitly set --add-self), if the primary
+	// calendar lookup fails we warn to stderr and continue with the original
+	// attendees — event creation must not break because of an opt-in convenience.
+	// If the user explicitly passed --add-self=true, the failure is fatal.
 	if addSelf {
 		selfEmail, lookupErr := getSelfCalendarEmail(svc)
 		if lookupErr != nil {
-			return p.PrintError(fmt.Errorf("failed to resolve self email for --add-self: %w (pass --add-self=false to skip)", lookupErr))
-		}
-		if !attendeeListContainsEmail(event.Attendees, selfEmail) {
+			if cmd.Flags().Changed("add-self") {
+				return p.PrintError(fmt.Errorf("failed to resolve self email for --add-self: %w (pass --add-self=false to skip)", lookupErr))
+			}
+			fmt.Fprintf(os.Stderr, "warning: --add-self default could not resolve primary calendar (%v); creating event without self attendee\n", lookupErr)
+		} else if !attendeeListContainsEmail(event.Attendees, selfEmail) {
 			event.Attendees = append(event.Attendees, &calendar.EventAttendee{
 				Email:          selfEmail,
 				ResponseStatus: "accepted",

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -612,18 +612,27 @@ func runCalendarEvents(cmd *cobra.Command, args []string) error {
 	})
 }
 
+// calendarServiceForTest, when non-nil, replaces the factory-built calendar
+// service in runCalendarCreate. Tests set this to point at httptest endpoints;
+// production code never assigns it so the factory path is taken.
+var calendarServiceForTest *calendar.Service
+
 func runCalendarCreate(cmd *cobra.Command, args []string) error {
 	p := GetPrinter()
 	ctx := context.Background()
 
-	factory, err := client.NewFactory(ctx)
-	if err != nil {
-		return p.PrintError(err)
-	}
-
-	svc, err := factory.Calendar()
-	if err != nil {
-		return p.PrintError(err)
+	var svc *calendar.Service
+	if calendarServiceForTest != nil {
+		svc = calendarServiceForTest
+	} else {
+		factory, err := client.NewFactory(ctx)
+		if err != nil {
+			return p.PrintError(err)
+		}
+		svc, err = factory.Calendar()
+		if err != nil {
+			return p.PrintError(err)
+		}
 	}
 
 	title, _ := cmd.Flags().GetString("title")
@@ -671,20 +680,21 @@ func runCalendarCreate(cmd *cobra.Command, args []string) error {
 		event.Attendees = eventAttendees
 	}
 
-	// Add the authenticated user as an accepted attendee unless --no-add-self is set.
+	// Add the authenticated user as an accepted attendee unless --add-self=false.
 	// The Calendar API does not auto-include the organizer in attendees, so downstream
 	// consumers checking attendees[].self/email get a missing entry for events you
 	// created. Mirrors the Calendar UI which always shows the organizer as attending.
+	// Note: attendees[].self is read-only; we set Email + ResponseStatus only and let
+	// the API populate self on the returned event.
 	if addSelf {
 		selfEmail, lookupErr := getSelfCalendarEmail(svc)
 		if lookupErr != nil {
-			return p.PrintError(fmt.Errorf("failed to resolve self email for --add-self: %w (pass --no-add-self to skip)", lookupErr))
+			return p.PrintError(fmt.Errorf("failed to resolve self email for --add-self: %w (pass --add-self=false to skip)", lookupErr))
 		}
 		if !attendeeListContainsEmail(event.Attendees, selfEmail) {
 			event.Attendees = append(event.Attendees, &calendar.EventAttendee{
 				Email:          selfEmail,
 				ResponseStatus: "accepted",
-				Self:           true,
 			})
 		}
 	}

--- a/cmd/calendar_test.go
+++ b/cmd/calendar_test.go
@@ -2118,7 +2118,7 @@ func TestCalendarCreate_AddsSelfByDefault(t *testing.T) {
 			_ = json.Unmarshal(body, inserted)
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"id":      "evt-1",
+				"id":       "evt-1",
 				"htmlLink": "https://calendar.google.com/event?eid=1",
 			})
 		default:
@@ -2189,15 +2189,22 @@ func TestCalendarCreate_DoesNotDuplicateSelf(t *testing.T) {
 		{Email: "other@example.com"},
 	}
 	selfEmail := "user@example.com"
+
+	// Mirror the runner's --add-self branch: only append when self is absent.
 	if !attendeeListContainsEmail(atts, selfEmail) {
-		t.Fatal("expected case-insensitive containment to find self")
+		atts = append(atts, &calendar.EventAttendee{
+			Email:          selfEmail,
+			ResponseStatus: "accepted",
+			Self:           true,
+		})
 	}
-	// Simulate the addSelf branch behavior: don't append.
-	if attendeeListContainsEmail(atts, selfEmail) {
-		// no-op: we should NOT append
-	}
+
 	if len(atts) != 2 {
 		t.Errorf("attendees should remain 2 after dedupe, got %d", len(atts))
+	}
+	// Confirm the original case-preserved entry is intact (we did not rewrite it).
+	if atts[0].Email != "User@Example.com" {
+		t.Errorf("original attendee email mutated: %s", atts[0].Email)
 	}
 }
 

--- a/cmd/calendar_test.go
+++ b/cmd/calendar_test.go
@@ -2211,6 +2211,74 @@ func TestCalendarCreate_AddsSelfByDefault(t *testing.T) {
 	}
 }
 
+// TestCalendarCreate_PrimaryLookupFailureDefaultPath proves event creation
+// continues even if Calendars.Get("primary") fails on the default --add-self
+// path. Existing event creation must not break because of an opt-in convenience.
+// On the default path the failure is a stderr warning; only an explicit
+// --add-self=true makes the failure fatal.
+func TestCalendarCreate_PrimaryLookupFailureDefaultPath(t *testing.T) {
+	var insertedRaw []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/calendars/primary":
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == "POST" && r.URL.Path == "/calendars/primary/events":
+			body, _ := readJSONBody(r)
+			insertedRaw = body
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "evt-3"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	svc, err := calendar.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create calendar service: %v", err)
+	}
+	calendarServiceForTest = svc
+	defer func() { calendarServiceForTest = nil }()
+
+	cmd := newCalendarCreateCmd()
+	_ = cmd.Flags().Set("title", "Test event")
+	_ = cmd.Flags().Set("start", "2026-04-28 15:00")
+	_ = cmd.Flags().Set("end", "2026-04-28 15:30")
+	_ = cmd.Flags().Set("attendees", "someone-else@example.com")
+	// Note: --add-self left at default true and NOT explicitly set.
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		os.Stdout = oldStdout
+		t.Fatalf("runCalendarCreate must not error on default add-self primary lookup failure; got %v", err)
+	}
+	w.Close()
+	os.Stdout = oldStdout
+	output, _ := io.ReadAll(r)
+
+	var stdoutResult map[string]interface{}
+	if err := json.Unmarshal(output, &stdoutResult); err != nil {
+		t.Fatalf("failed to parse stdout: %v\nraw: %s", err, output)
+	}
+	if stdoutResult["status"] != "created" {
+		t.Errorf("expected status=created on default-path lookup failure; got %v\nraw: %s", stdoutResult["status"], output)
+	}
+	if insertedRaw == nil {
+		t.Fatal("server did not capture inserted event — POST should still happen on default-path lookup failure")
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(insertedRaw, &raw); err != nil {
+		t.Fatalf("failed to parse inserted body: %v\nraw: %s", err, insertedRaw)
+	}
+	rawAttendees, _ := raw["attendees"].([]interface{})
+	if len(rawAttendees) != 1 {
+		t.Fatalf("expected 1 attendee (no self appended after lookup failure), got %d (raw: %s)", len(rawAttendees), insertedRaw)
+	}
+}
+
 // TestCalendarCreate_RespectsAddSelfFalse drives the runner with --add-self=false
 // and asserts no GET /calendars/primary call is made and no self attendee is appended.
 func TestCalendarCreate_RespectsAddSelfFalse(t *testing.T) {

--- a/cmd/calendar_test.go
+++ b/cmd/calendar_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -2035,4 +2036,176 @@ func TestCalendarEvents_FromFlag_DateParsing(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAttendeeListContainsEmail verifies case-insensitive email lookup with
+// nil-tolerance, used by --add-self to skip duplicate attendees.
+func TestAttendeeListContainsEmail(t *testing.T) {
+	atts := []*calendar.EventAttendee{
+		{Email: "Alice@Example.com"},
+		nil,
+		{Email: "bob@example.com"},
+	}
+	cases := []struct {
+		name  string
+		email string
+		want  bool
+	}{
+		{"exact match lowercase", "alice@example.com", true},
+		{"exact match preserved case", "Alice@Example.com", true},
+		{"different case in list", "ALICE@EXAMPLE.COM", true},
+		{"second entry", "bob@example.com", true},
+		{"absent", "carol@example.com", false},
+		{"empty input", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := attendeeListContainsEmail(atts, tc.email); got != tc.want {
+				t.Errorf("attendeeListContainsEmail(_, %q) = %v, want %v", tc.email, got, tc.want)
+			}
+		})
+	}
+	if attendeeListContainsEmail(nil, "alice@example.com") {
+		t.Error("nil slice should return false")
+	}
+}
+
+// TestGetSelfCalendarEmail_MockServer verifies the helper returns the primary
+// calendar's id (which Calendar API populates with the user's email).
+func TestGetSelfCalendarEmail_MockServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" && r.URL.Path == "/calendars/primary" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":      "user@example.com",
+				"summary": "user@example.com",
+			})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	svc, err := calendar.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create calendar service: %v", err)
+	}
+
+	email, err := getSelfCalendarEmail(svc)
+	if err != nil {
+		t.Fatalf("getSelfCalendarEmail returned error: %v", err)
+	}
+	if email != "user@example.com" {
+		t.Errorf("expected 'user@example.com', got %q", email)
+	}
+}
+
+// TestCalendarCreate_AddsSelfByDefault verifies that Events.Insert receives the
+// authenticated user as an accepted attendee when --add-self is unset (default true).
+func TestCalendarCreate_AddsSelfByDefault(t *testing.T) {
+	var inserted *calendar.Event
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/calendars/primary":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id": "user@example.com",
+			})
+		case r.Method == "POST" && r.URL.Path == "/calendars/primary/events":
+			body, _ := readJSONBody(r)
+			inserted = &calendar.Event{}
+			_ = json.Unmarshal(body, inserted)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":      "evt-1",
+				"htmlLink": "https://calendar.google.com/event?eid=1",
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	svc, err := calendar.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create calendar service: %v", err)
+	}
+
+	// Simulate runCalendarCreate's --add-self path directly (no Cobra plumbing).
+	event := &calendar.Event{
+		Summary: "Test",
+		Attendees: []*calendar.EventAttendee{
+			{Email: "someone-else@example.com"},
+		},
+	}
+
+	selfEmail, err := getSelfCalendarEmail(svc)
+	if err != nil {
+		t.Fatalf("getSelfCalendarEmail: %v", err)
+	}
+	if !attendeeListContainsEmail(event.Attendees, selfEmail) {
+		event.Attendees = append(event.Attendees, &calendar.EventAttendee{
+			Email:          selfEmail,
+			ResponseStatus: "accepted",
+			Self:           true,
+		})
+	}
+
+	_, err = svc.Events.Insert("primary", event).Do()
+	if err != nil {
+		t.Fatalf("Events.Insert: %v", err)
+	}
+
+	if inserted == nil {
+		t.Fatal("server did not capture inserted event")
+	}
+	if len(inserted.Attendees) != 2 {
+		t.Fatalf("expected 2 attendees, got %d", len(inserted.Attendees))
+	}
+	var found *calendar.EventAttendee
+	for _, a := range inserted.Attendees {
+		if a.Email == "user@example.com" {
+			found = a
+		}
+	}
+	if found == nil {
+		t.Fatal("self attendee user@example.com not found in inserted attendees")
+	}
+	if found.ResponseStatus != "accepted" {
+		t.Errorf("self responseStatus: got %q, want accepted", found.ResponseStatus)
+	}
+	if !found.Self {
+		t.Errorf("self flag: expected true, got false")
+	}
+}
+
+// TestCalendarCreate_DoesNotDuplicateSelf verifies that when the user passes
+// themselves in --attendees explicitly, --add-self does not duplicate the row.
+func TestCalendarCreate_DoesNotDuplicateSelf(t *testing.T) {
+	atts := []*calendar.EventAttendee{
+		{Email: "User@Example.com"},
+		{Email: "other@example.com"},
+	}
+	selfEmail := "user@example.com"
+	if !attendeeListContainsEmail(atts, selfEmail) {
+		t.Fatal("expected case-insensitive containment to find self")
+	}
+	// Simulate the addSelf branch behavior: don't append.
+	if attendeeListContainsEmail(atts, selfEmail) {
+		// no-op: we should NOT append
+	}
+	if len(atts) != 2 {
+		t.Errorf("attendees should remain 2 after dedupe, got %d", len(atts))
+	}
+}
+
+// readJSONBody reads the request body as bytes for inspection.
+func readJSONBody(r *http.Request) ([]byte, error) {
+	if r.Body == nil {
+		return nil, nil
+	}
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
 }

--- a/cmd/calendar_test.go
+++ b/cmd/calendar_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 )
@@ -2101,23 +2102,43 @@ func TestGetSelfCalendarEmail_MockServer(t *testing.T) {
 	}
 }
 
-// TestCalendarCreate_AddsSelfByDefault verifies that Events.Insert receives the
-// authenticated user as an accepted attendee when --add-self is unset (default true).
+// newCalendarCreateCmd returns a fresh create command for tests, mirroring the
+// flags registered in init(). Avoids global flag-state bleed between tests.
+func newCalendarCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "create",
+		RunE: runCalendarCreate,
+	}
+	cmd.Flags().String("title", "", "Event title (required)")
+	cmd.Flags().String("start", "", "Start time")
+	cmd.Flags().String("end", "", "End time")
+	cmd.Flags().String("calendar-id", "primary", "Calendar ID")
+	cmd.Flags().String("description", "", "Event description")
+	cmd.Flags().String("location", "", "Event location")
+	cmd.Flags().StringSlice("attendees", nil, "Attendee emails")
+	cmd.Flags().Bool("add-self", true, "Add the authenticated user as an accepted attendee")
+	return cmd
+}
+
+// TestCalendarCreate_AddsSelfByDefault drives runCalendarCreate via the Cobra
+// command path with default --add-self. The mock server captures the GET on
+// /calendars/primary and the POST on /calendars/primary/events, then we assert
+// the outbound payload contains self as an accepted attendee with no `self`
+// field set (the API treats that field as read-only).
 func TestCalendarCreate_AddsSelfByDefault(t *testing.T) {
-	var inserted *calendar.Event
+	var insertedRaw []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == "GET" && r.URL.Path == "/calendars/primary":
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"id": "user@example.com",
 			})
 		case r.Method == "POST" && r.URL.Path == "/calendars/primary/events":
 			body, _ := readJSONBody(r)
-			inserted = &calendar.Event{}
-			_ = json.Unmarshal(body, inserted)
+			insertedRaw = body
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"id":       "evt-1",
 				"htmlLink": "https://calendar.google.com/event?eid=1",
 			})
@@ -2132,52 +2153,128 @@ func TestCalendarCreate_AddsSelfByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create calendar service: %v", err)
 	}
+	calendarServiceForTest = svc
+	defer func() { calendarServiceForTest = nil }()
 
-	// Simulate runCalendarCreate's --add-self path directly (no Cobra plumbing).
-	event := &calendar.Event{
-		Summary: "Test",
-		Attendees: []*calendar.EventAttendee{
-			{Email: "someone-else@example.com"},
-		},
+	cmd := newCalendarCreateCmd()
+	_ = cmd.Flags().Set("title", "Test event")
+	_ = cmd.Flags().Set("start", "2026-04-28 15:00")
+	_ = cmd.Flags().Set("end", "2026-04-28 15:30")
+	_ = cmd.Flags().Set("attendees", "someone-else@example.com")
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		os.Stdout = oldStdout
+		t.Fatalf("runCalendarCreate returned error: %v", err)
+	}
+	w.Close()
+	os.Stdout = oldStdout
+
+	output, _ := io.ReadAll(r)
+	var stdoutResult map[string]interface{}
+	if err := json.Unmarshal(output, &stdoutResult); err != nil {
+		t.Fatalf("failed to parse stdout: %v\nraw: %s", err, output)
+	}
+	if stdoutResult["status"] != "created" {
+		t.Errorf("stdout status: got %v, want created", stdoutResult["status"])
 	}
 
-	selfEmail, err := getSelfCalendarEmail(svc)
-	if err != nil {
-		t.Fatalf("getSelfCalendarEmail: %v", err)
-	}
-	if !attendeeListContainsEmail(event.Attendees, selfEmail) {
-		event.Attendees = append(event.Attendees, &calendar.EventAttendee{
-			Email:          selfEmail,
-			ResponseStatus: "accepted",
-			Self:           true,
-		})
-	}
-
-	_, err = svc.Events.Insert("primary", event).Do()
-	if err != nil {
-		t.Fatalf("Events.Insert: %v", err)
-	}
-
-	if inserted == nil {
+	if insertedRaw == nil {
 		t.Fatal("server did not capture inserted event")
 	}
-	if len(inserted.Attendees) != 2 {
-		t.Fatalf("expected 2 attendees, got %d", len(inserted.Attendees))
+	// Inspect the raw JSON the SDK sent so we can prove `self` was NOT serialized.
+	var raw map[string]interface{}
+	if err := json.Unmarshal(insertedRaw, &raw); err != nil {
+		t.Fatalf("failed to parse inserted body: %v\nraw: %s", err, insertedRaw)
 	}
-	var found *calendar.EventAttendee
-	for _, a := range inserted.Attendees {
-		if a.Email == "user@example.com" {
-			found = a
+	rawAttendees, _ := raw["attendees"].([]interface{})
+	if len(rawAttendees) != 2 {
+		t.Fatalf("expected 2 attendees in payload, got %d (raw: %s)", len(rawAttendees), insertedRaw)
+	}
+	var selfRow map[string]interface{}
+	for _, a := range rawAttendees {
+		row, _ := a.(map[string]interface{})
+		if row["email"] == "user@example.com" {
+			selfRow = row
 		}
 	}
-	if found == nil {
-		t.Fatal("self attendee user@example.com not found in inserted attendees")
+	if selfRow == nil {
+		t.Fatal("self attendee user@example.com not found in payload")
 	}
-	if found.ResponseStatus != "accepted" {
-		t.Errorf("self responseStatus: got %q, want accepted", found.ResponseStatus)
+	if selfRow["responseStatus"] != "accepted" {
+		t.Errorf("self responseStatus: got %v, want accepted", selfRow["responseStatus"])
 	}
-	if !found.Self {
-		t.Errorf("self flag: expected true, got false")
+	if _, present := selfRow["self"]; present {
+		t.Errorf("payload should not include `self` field (it is read-only); got %v", selfRow["self"])
+	}
+}
+
+// TestCalendarCreate_RespectsAddSelfFalse drives the runner with --add-self=false
+// and asserts no GET /calendars/primary call is made and no self attendee is appended.
+func TestCalendarCreate_RespectsAddSelfFalse(t *testing.T) {
+	var primaryCalled bool
+	var insertedRaw []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/calendars/primary":
+			primaryCalled = true
+			w.WriteHeader(http.StatusInternalServerError) // should not be reached
+		case r.Method == "POST" && r.URL.Path == "/calendars/primary/events":
+			body, _ := readJSONBody(r)
+			insertedRaw = body
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"id": "evt-2"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	svc, err := calendar.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create calendar service: %v", err)
+	}
+	calendarServiceForTest = svc
+	defer func() { calendarServiceForTest = nil }()
+
+	cmd := newCalendarCreateCmd()
+	_ = cmd.Flags().Set("title", "Test event")
+	_ = cmd.Flags().Set("start", "2026-04-28 15:00")
+	_ = cmd.Flags().Set("end", "2026-04-28 15:30")
+	_ = cmd.Flags().Set("attendees", "someone-else@example.com")
+	_ = cmd.Flags().Set("add-self", "false")
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		os.Stdout = oldStdout
+		t.Fatalf("runCalendarCreate returned error: %v", err)
+	}
+	w.Close()
+	os.Stdout = oldStdout
+	_, _ = io.ReadAll(r)
+
+	if primaryCalled {
+		t.Error("GET /calendars/primary should not be called when --add-self=false")
+	}
+	if insertedRaw == nil {
+		t.Fatal("server did not capture inserted event")
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(insertedRaw, &raw); err != nil {
+		t.Fatalf("failed to parse inserted body: %v\nraw: %s", err, insertedRaw)
+	}
+	rawAttendees, _ := raw["attendees"].([]interface{})
+	if len(rawAttendees) != 1 {
+		t.Fatalf("expected 1 attendee with --add-self=false, got %d (raw: %s)", len(rawAttendees), insertedRaw)
+	}
+	row, _ := rawAttendees[0].(map[string]interface{})
+	if row["email"] != "someone-else@example.com" {
+		t.Errorf("unexpected attendee email: %v", row["email"])
 	}
 }
 
@@ -2191,11 +2288,11 @@ func TestCalendarCreate_DoesNotDuplicateSelf(t *testing.T) {
 	selfEmail := "user@example.com"
 
 	// Mirror the runner's --add-self branch: only append when self is absent.
+	// We do not set Self here — Calendar API treats attendees[].self as read-only.
 	if !attendeeListContainsEmail(atts, selfEmail) {
 		atts = append(atts, &calendar.EventAttendee{
 			Email:          selfEmail,
 			ResponseStatus: "accepted",
-			Self:           true,
 		})
 	}
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -307,8 +307,16 @@ var chatFindSpaceCmd = &cobra.Command{
 	Use:   "find-space",
 	Short: "Find spaces by display name",
 	Long: `Searches the local space cache for spaces whose display_name contains the
-given query (case-insensitive substring match). Run 'gws chat build-cache' first
-or pass --refresh to rebuild the cache before searching.`,
+given query (case-insensitive substring match).
+
+The cache must already cover the space type you want to search. The default
+'gws chat build-cache' run only caches GROUP_CHAT, so to search SPACE-type
+rooms or all types either:
+  - prebuild with 'gws chat build-cache --type SPACE' (or '--type all'), or
+  - pass --refresh to rebuild the cache from spaces.list before searching.
+
+When --refresh is set together with --type, the cache is rebuilt scoped to that
+type only; otherwise --refresh rebuilds for all space types.`,
 	RunE: runChatFindSpace,
 }
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -2182,14 +2183,34 @@ func runChatFindSpace(cmd *cobra.Command, args []string) error {
 
 	matches := spacecache.FindByDisplayName(cache, name, spaceType)
 
-	results := make([]map[string]interface{}, 0, len(matches))
+	type matchRow struct {
+		space, displayName string
+		entry              spacecache.SpaceEntry
+	}
+	rows := make([]matchRow, 0, len(matches))
 	for spaceName, entry := range matches {
-		results = append(results, map[string]interface{}{
-			"space":        spaceName,
-			"type":         entry.Type,
-			"display_name": entry.DisplayName,
-			"member_count": entry.MemberCount,
-		})
+		rows = append(rows, matchRow{space: spaceName, displayName: entry.DisplayName, entry: entry})
+	}
+	// Stable order across runs: by display_name, then by space resource name.
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].displayName != rows[j].displayName {
+			return rows[i].displayName < rows[j].displayName
+		}
+		return rows[i].space < rows[j].space
+	})
+
+	results := make([]map[string]interface{}, 0, len(rows))
+	for _, r := range rows {
+		row := map[string]interface{}{
+			"space":        r.space,
+			"type":         r.entry.Type,
+			"display_name": r.entry.DisplayName,
+			"member_count": r.entry.MemberCount,
+		}
+		if r.entry.MembersUnresolved {
+			row["members_unresolved"] = true
+		}
+		results = append(results, row)
 	}
 
 	out := map[string]interface{}{

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -15,6 +15,7 @@ import (
 	"github.com/omriariav/workspace-cli/internal/usercache"
 	"github.com/spf13/cobra"
 	"google.golang.org/api/chat/v1"
+	"google.golang.org/api/people/v1"
 )
 
 var chatCmd = &cobra.Command{
@@ -2100,6 +2101,15 @@ func runChatFindGroup(cmd *cobra.Command, args []string) error {
 	})
 }
 
+// chatServiceForTest and peopleServiceForTest, when non-nil, replace the
+// factory-built services in runChatFindSpace's --refresh path. Tests set these
+// to point at httptest endpoints; production paths leave both nil so the
+// factory is used.
+var (
+	chatServiceForTest   *chat.Service
+	peopleServiceForTest *people.Service
+)
+
 func runChatFindSpace(cmd *cobra.Command, args []string) error {
 	p := GetPrinter()
 	ctx := context.Background()
@@ -2124,19 +2134,24 @@ func runChatFindSpace(cmd *cobra.Command, args []string) error {
 	cachePath := spacecache.DefaultPath()
 
 	if refresh {
-		factory, err := client.NewFactory(ctx)
-		if err != nil {
-			return p.PrintError(err)
-		}
-
-		chatSvc, err := factory.Chat()
-		if err != nil {
-			return p.PrintError(err)
-		}
-
-		peopleSvc, err := factory.People()
-		if err != nil {
-			return p.PrintError(err)
+		var chatSvc *chat.Service
+		var peopleSvc *people.Service
+		if chatServiceForTest != nil {
+			chatSvc = chatServiceForTest
+			peopleSvc = peopleServiceForTest
+		} else {
+			factory, err := client.NewFactory(ctx)
+			if err != nil {
+				return p.PrintError(err)
+			}
+			chatSvc, err = factory.Chat()
+			if err != nil {
+				return p.PrintError(err)
+			}
+			peopleSvc, err = factory.People()
+			if err != nil {
+				return p.PrintError(err)
+			}
 		}
 
 		buildType := "all"

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -2096,11 +2096,12 @@ func runChatFindSpace(cmd *cobra.Command, args []string) error {
 	p := GetPrinter()
 	ctx := context.Background()
 
-	name, _ := cmd.Flags().GetString("name")
+	rawName, _ := cmd.Flags().GetString("name")
 	spaceType, _ := cmd.Flags().GetString("type")
 	refresh, _ := cmd.Flags().GetBool("refresh")
 
-	if strings.TrimSpace(name) == "" {
+	name := strings.TrimSpace(rawName)
+	if name == "" {
 		return p.PrintError(fmt.Errorf("--name must not be empty"))
 	}
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -303,6 +303,15 @@ var chatFindGroupCmd = &cobra.Command{
 	RunE:  runChatFindGroup,
 }
 
+var chatFindSpaceCmd = &cobra.Command{
+	Use:   "find-space",
+	Short: "Find spaces by display name",
+	Long: `Searches the local space cache for spaces whose display_name contains the
+given query (case-insensitive substring match). Run 'gws chat build-cache' first
+or pass --refresh to rebuild the cache before searching.`,
+	RunE: runChatFindSpace,
+}
+
 func init() {
 	rootCmd.AddCommand(chatCmd)
 	chatCmd.AddCommand(chatListCmd)
@@ -337,6 +346,7 @@ func init() {
 	chatCmd.AddCommand(chatEventCmd)
 	chatCmd.AddCommand(chatBuildCacheCmd)
 	chatCmd.AddCommand(chatFindGroupCmd)
+	chatCmd.AddCommand(chatFindSpaceCmd)
 
 	// List flags
 	chatListCmd.Flags().String("filter", "", "Filter spaces (e.g. 'spaceType = \"SPACE\"')")
@@ -441,6 +451,12 @@ func init() {
 	chatFindGroupCmd.Flags().String("members", "", "Comma-separated email addresses to search for (required)")
 	chatFindGroupCmd.Flags().Bool("refresh", false, "Rebuild cache before searching")
 	chatFindGroupCmd.MarkFlagRequired("members")
+
+	// Find space flags
+	chatFindSpaceCmd.Flags().String("name", "", "Display name substring to search for (case-insensitive, required)")
+	chatFindSpaceCmd.Flags().String("type", "", "Filter by space type: SPACE, GROUP_CHAT, or DIRECT_MESSAGE")
+	chatFindSpaceCmd.Flags().Bool("refresh", false, "Rebuild cache before searching")
+	chatFindSpaceCmd.MarkFlagRequired("name")
 }
 
 // ensureSpaceName normalizes a space identifier to its full resource name.
@@ -449,6 +465,59 @@ func ensureSpaceName(s string) string {
 		return "spaces/" + s
 	}
 	return s
+}
+
+// serializeChatAttachments converts a Message.Attachment slice into a JSON-friendly
+// shape, exposing the resource name needed by `gws chat attachment` and
+// `gws chat download`. Returns nil when there are no attachments so the field
+// is omitted from output by callers that check for nil.
+func serializeChatAttachments(atts []*chat.Attachment) []map[string]interface{} {
+	if len(atts) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, 0, len(atts))
+	for _, a := range atts {
+		if a == nil {
+			continue
+		}
+		entry := map[string]interface{}{}
+		if a.Name != "" {
+			entry["name"] = a.Name
+		}
+		if a.ContentName != "" {
+			entry["content_name"] = a.ContentName
+		}
+		if a.ContentType != "" {
+			entry["content_type"] = a.ContentType
+		}
+		if a.Source != "" {
+			entry["source"] = a.Source
+		}
+		if a.DownloadUri != "" {
+			entry["download_uri"] = a.DownloadUri
+		}
+		if a.ThumbnailUri != "" {
+			entry["thumbnail_uri"] = a.ThumbnailUri
+		}
+		if a.AttachmentDataRef != nil && a.AttachmentDataRef.ResourceName != "" {
+			entry["attachment_data_ref"] = map[string]interface{}{
+				"resource_name": a.AttachmentDataRef.ResourceName,
+			}
+		}
+		if a.DriveDataRef != nil && a.DriveDataRef.DriveFileId != "" {
+			entry["drive_data_ref"] = map[string]interface{}{
+				"drive_file_id": a.DriveDataRef.DriveFileId,
+			}
+		}
+		if len(entry) == 0 {
+			continue
+		}
+		out = append(out, entry)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func runChatList(cmd *cobra.Command, args []string) error {
@@ -607,6 +676,9 @@ func runChatMessages(cmd *cobra.Command, args []string) error {
 			}
 			if msg.DeleteTime != "" {
 				msgInfo["delete_time"] = msg.DeleteTime
+			}
+			if atts := serializeChatAttachments(msg.Attachment); atts != nil {
+				msgInfo["attachment"] = atts
 			}
 			results = append(results, msgInfo)
 		}
@@ -829,6 +901,9 @@ func runChatGet(cmd *cobra.Command, args []string) error {
 	}
 	if msg.DeleteTime != "" {
 		result["delete_time"] = msg.DeleteTime
+	}
+	if atts := serializeChatAttachments(msg.Attachment); atts != nil {
+		result["attachment"] = atts
 	}
 
 	return p.Print(result)
@@ -1642,6 +1717,9 @@ func runChatUnread(cmd *cobra.Command, args []string) error {
 			if msg.Thread != nil {
 				msgInfo["thread"] = msg.Thread.Name
 			}
+			if atts := serializeChatAttachments(msg.Attachment); atts != nil {
+				msgInfo["attachment"] = atts
+			}
 			messages = append(messages, msgInfo)
 		}
 
@@ -2012,4 +2090,91 @@ func runChatFindGroup(cmd *cobra.Command, args []string) error {
 		"count":   len(results),
 		"query":   emails,
 	})
+}
+
+func runChatFindSpace(cmd *cobra.Command, args []string) error {
+	p := GetPrinter()
+	ctx := context.Background()
+
+	name, _ := cmd.Flags().GetString("name")
+	spaceType, _ := cmd.Flags().GetString("type")
+	refresh, _ := cmd.Flags().GetBool("refresh")
+
+	if strings.TrimSpace(name) == "" {
+		return p.PrintError(fmt.Errorf("--name must not be empty"))
+	}
+
+	if spaceType != "" {
+		switch strings.ToUpper(spaceType) {
+		case "SPACE", "GROUP_CHAT", "DIRECT_MESSAGE":
+		default:
+			return p.PrintError(fmt.Errorf("invalid --type %q: must be SPACE, GROUP_CHAT, or DIRECT_MESSAGE", spaceType))
+		}
+	}
+
+	cachePath := spacecache.DefaultPath()
+
+	if refresh {
+		factory, err := client.NewFactory(ctx)
+		if err != nil {
+			return p.PrintError(err)
+		}
+
+		chatSvc, err := factory.Chat()
+		if err != nil {
+			return p.PrintError(err)
+		}
+
+		peopleSvc, err := factory.People()
+		if err != nil {
+			return p.PrintError(err)
+		}
+
+		buildType := "all"
+		if spaceType != "" {
+			buildType = strings.ToUpper(spaceType)
+		}
+		cache, err := spacecache.Build(ctx, chatSvc, peopleSvc, buildType, func(current, total int) {
+			fmt.Fprintf(os.Stderr, "\rScanning spaces... %d/%d", current, total)
+		})
+		if err != nil {
+			return p.PrintError(fmt.Errorf("failed to build cache: %w", err))
+		}
+		fmt.Fprintln(os.Stderr)
+
+		if err := spacecache.Save(cachePath, cache); err != nil {
+			return p.PrintError(fmt.Errorf("failed to save cache: %w", err))
+		}
+	}
+
+	cache, err := spacecache.Load(cachePath)
+	if err != nil {
+		return p.PrintError(fmt.Errorf("failed to load cache: %w", err))
+	}
+
+	if len(cache.Spaces) == 0 {
+		return p.PrintError(fmt.Errorf("no cache found — run 'gws chat build-cache' first or pass --refresh"))
+	}
+
+	matches := spacecache.FindByDisplayName(cache, name, spaceType)
+
+	results := make([]map[string]interface{}, 0, len(matches))
+	for spaceName, entry := range matches {
+		results = append(results, map[string]interface{}{
+			"space":        spaceName,
+			"type":         entry.Type,
+			"display_name": entry.DisplayName,
+			"member_count": entry.MemberCount,
+		})
+	}
+
+	out := map[string]interface{}{
+		"matches": results,
+		"count":   len(results),
+		"query":   name,
+	}
+	if spaceType != "" {
+		out["type"] = strings.ToUpper(spaceType)
+	}
+	return p.Print(out)
 }

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -3371,18 +3371,29 @@ func TestChatFindSpace_RefreshTypeScoped(t *testing.T) {
 		t.Fatalf("expected 2 matches (resolved + metadata-only), got %v\nraw: %s", count, output)
 	}
 	matches, _ := result["matches"].([]interface{})
-	gotNames := map[string]bool{}
-	for _, m := range matches {
-		row, _ := m.(map[string]interface{})
-		if s, _ := row["space"].(string); s != "" {
-			gotNames[s] = true
-		}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 entries in matches array, got %d", len(matches))
 	}
-	if !gotNames["spaces/AAA"] {
-		t.Error("expected spaces/AAA in matches")
+
+	// Sort is by display_name then space. "Sales Skills" < "Sales lunch crew"
+	// in byte order because 'S' (0x53) < 'l' (0x6c). AAA must come first.
+	first, _ := matches[0].(map[string]interface{})
+	second, _ := matches[1].(map[string]interface{})
+	if first["space"] != "spaces/AAA" {
+		t.Errorf("expected matches[0]=spaces/AAA, got %v", first["space"])
 	}
-	if !gotNames["spaces/BBB"] {
-		t.Error("expected spaces/BBB (metadata-only after member fetch failure) in matches")
+	if second["space"] != "spaces/BBB" {
+		t.Errorf("expected matches[1]=spaces/BBB, got %v", second["space"])
+	}
+
+	// Resolved entry should NOT carry members_unresolved.
+	if _, present := first["members_unresolved"]; present {
+		t.Errorf("spaces/AAA should not have members_unresolved set; got %v", first["members_unresolved"])
+	}
+	// Metadata-only entry (BBB) MUST carry members_unresolved=true so callers
+	// can distinguish it from a real zero-member space.
+	if v, _ := second["members_unresolved"].(bool); !v {
+		t.Errorf("spaces/BBB should have members_unresolved=true; got %v", second["members_unresolved"])
 	}
 
 	// Cache file should have been written to the temp HOME.

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -2943,6 +2943,19 @@ func newFindGroupCmd() *cobra.Command {
 	return cmd
 }
 
+// newFindSpaceCmd creates a fresh find-space command for tests.
+func newFindSpaceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "find-space",
+		Short: "Find spaces by display name",
+		RunE:  runChatFindSpace,
+	}
+	cmd.Flags().String("name", "", "Display name substring to search for (case-insensitive, required)")
+	cmd.Flags().String("type", "", "Filter by space type: SPACE, GROUP_CHAT, or DIRECT_MESSAGE")
+	cmd.Flags().Bool("refresh", false, "Rebuild cache before searching")
+	return cmd
+}
+
 func TestChatFindGroup_CommandE2E(t *testing.T) {
 	// Use temp HOME so DefaultPath() resolves to our temp dir
 	tmpHome := t.TempDir()
@@ -3057,6 +3070,252 @@ func TestChatFindGroup_ErrorOnEmptyMembers(t *testing.T) {
 	errMsg, ok := result["error"].(string)
 	if !ok || errMsg == "" {
 		t.Errorf("expected error message in output, got %v", result)
+	}
+}
+
+// TestSerializeChatAttachments_Empty verifies nil/empty input returns nil so callers
+// can omit the attachment field from output.
+func TestSerializeChatAttachments_Empty(t *testing.T) {
+	if got := serializeChatAttachments(nil); got != nil {
+		t.Errorf("nil input: expected nil, got %v", got)
+	}
+	if got := serializeChatAttachments([]*chat.Attachment{}); got != nil {
+		t.Errorf("empty slice: expected nil, got %v", got)
+	}
+	if got := serializeChatAttachments([]*chat.Attachment{nil, nil}); got != nil {
+		t.Errorf("slice of nils: expected nil, got %v", got)
+	}
+}
+
+// TestSerializeChatAttachments_AllFields verifies every populated field is forwarded
+// with snake_case keys, including the resource name needed by `gws chat attachment`
+// and `gws chat download`.
+func TestSerializeChatAttachments_AllFields(t *testing.T) {
+	atts := []*chat.Attachment{
+		{
+			Name:         "spaces/AAAA/messages/MMM/attachments/abc",
+			ContentName:  "resume.pdf",
+			ContentType:  "application/pdf",
+			Source:       "UPLOADED_CONTENT",
+			DownloadUri:  "https://example.com/d/abc",
+			ThumbnailUri: "https://example.com/t/abc",
+			AttachmentDataRef: &chat.AttachmentDataRef{
+				ResourceName: "spaces/AAAA/messages/MMM/attachments/abc",
+			},
+		},
+		{
+			ContentName: "linked.docx",
+			ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+			Source:      "DRIVE_FILE",
+			DriveDataRef: &chat.DriveDataRef{
+				DriveFileId: "1abcDriveID",
+			},
+		},
+	}
+
+	got := serializeChatAttachments(atts)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+
+	first := got[0]
+	if first["name"] != "spaces/AAAA/messages/MMM/attachments/abc" {
+		t.Errorf("first.name: got %v", first["name"])
+	}
+	if first["content_name"] != "resume.pdf" {
+		t.Errorf("first.content_name: got %v", first["content_name"])
+	}
+	if first["content_type"] != "application/pdf" {
+		t.Errorf("first.content_type: got %v", first["content_type"])
+	}
+	if first["source"] != "UPLOADED_CONTENT" {
+		t.Errorf("first.source: got %v", first["source"])
+	}
+	if first["download_uri"] != "https://example.com/d/abc" {
+		t.Errorf("first.download_uri: got %v", first["download_uri"])
+	}
+	if first["thumbnail_uri"] != "https://example.com/t/abc" {
+		t.Errorf("first.thumbnail_uri: got %v", first["thumbnail_uri"])
+	}
+	ref, ok := first["attachment_data_ref"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("first.attachment_data_ref: expected map, got %T", first["attachment_data_ref"])
+	}
+	if ref["resource_name"] != "spaces/AAAA/messages/MMM/attachments/abc" {
+		t.Errorf("first.attachment_data_ref.resource_name: got %v", ref["resource_name"])
+	}
+	if _, present := first["drive_data_ref"]; present {
+		t.Errorf("first should not have drive_data_ref, got %v", first["drive_data_ref"])
+	}
+
+	second := got[1]
+	if _, present := second["name"]; present {
+		t.Errorf("second.name should be omitted when empty")
+	}
+	if _, present := second["attachment_data_ref"]; present {
+		t.Errorf("second.attachment_data_ref should be omitted when empty")
+	}
+	dref, ok := second["drive_data_ref"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("second.drive_data_ref: expected map, got %T", second["drive_data_ref"])
+	}
+	if dref["drive_file_id"] != "1abcDriveID" {
+		t.Errorf("second.drive_data_ref.drive_file_id: got %v", dref["drive_file_id"])
+	}
+}
+
+// TestSerializeChatAttachments_SkipsEmptyEntries verifies entries with no populated
+// fields are dropped, and a slice that resolves to no entries returns nil.
+func TestSerializeChatAttachments_SkipsEmptyEntries(t *testing.T) {
+	if got := serializeChatAttachments([]*chat.Attachment{{}, nil, {}}); got != nil {
+		t.Errorf("all-empty input: expected nil, got %v", got)
+	}
+
+	atts := []*chat.Attachment{
+		{}, // empty, dropped
+		{ContentName: "kept.pdf"},
+		nil,
+	}
+	got := serializeChatAttachments(atts)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry after filtering, got %d (%v)", len(got), got)
+	}
+	if got[0]["content_name"] != "kept.pdf" {
+		t.Errorf("kept entry content_name: got %v", got[0]["content_name"])
+	}
+}
+
+// TestChatFindSpace_MatchesByDisplayName verifies the runner reads the on-disk
+// cache and emits matching spaces by display name (case-insensitive substring).
+func TestChatFindSpace_MatchesByDisplayName(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	cache := &spacecache.CacheData{
+		Spaces: map[string]spacecache.SpaceEntry{
+			"spaces/A": {Type: "SPACE", DisplayName: "Sales Skills", MemberCount: 3},
+			"spaces/B": {Type: "GROUP_CHAT", DisplayName: "Sales lunch crew", MemberCount: 4},
+			"spaces/C": {Type: "SPACE", DisplayName: "Engineering", MemberCount: 12},
+		},
+	}
+	if err := spacecache.Save(spacecache.DefaultPath(), cache); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	cmd := newFindSpaceCmd()
+	cmd.Flags().Set("name", "sales")
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	cmd.RunE(cmd, []string{})
+	w.Close()
+	os.Stdout = oldStdout
+
+	output, _ := io.ReadAll(r)
+	var result map[string]interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("failed to parse output: %v\nraw: %s", err, output)
+	}
+	count, _ := result["count"].(float64)
+	if int(count) != 2 {
+		t.Errorf("expected 2 matches for 'sales', got %v (raw: %s)", count, output)
+	}
+}
+
+// TestChatFindSpace_TypeFilter verifies --type narrows results by space type.
+func TestChatFindSpace_TypeFilter(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	cache := &spacecache.CacheData{
+		Spaces: map[string]spacecache.SpaceEntry{
+			"spaces/A": {Type: "SPACE", DisplayName: "Sales Skills", MemberCount: 3},
+			"spaces/B": {Type: "GROUP_CHAT", DisplayName: "Sales lunch crew", MemberCount: 4},
+		},
+	}
+	if err := spacecache.Save(spacecache.DefaultPath(), cache); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	cmd := newFindSpaceCmd()
+	cmd.Flags().Set("name", "sales")
+	cmd.Flags().Set("type", "SPACE")
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	cmd.RunE(cmd, []string{})
+	w.Close()
+	os.Stdout = oldStdout
+
+	output, _ := io.ReadAll(r)
+	var result map[string]interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("failed to parse output: %v\nraw: %s", err, output)
+	}
+	count, _ := result["count"].(float64)
+	if int(count) != 1 {
+		t.Errorf("expected 1 SPACE match for 'sales', got %v (raw: %s)", count, output)
+	}
+}
+
+// TestChatFindSpace_InvalidType verifies bogus --type emits an error.
+func TestChatFindSpace_InvalidType(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	cmd := newFindSpaceCmd()
+	cmd.Flags().Set("name", "sales")
+	cmd.Flags().Set("type", "BOGUS")
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	cmd.RunE(cmd, []string{})
+	w.Close()
+	os.Stdout = oldStdout
+
+	output, _ := io.ReadAll(r)
+	var result map[string]interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("failed to parse output: %v\nraw: %s", err, output)
+	}
+	if msg, _ := result["error"].(string); msg == "" {
+		t.Errorf("expected error in output, got %v", result)
+	}
+}
+
+// TestChatFindSpace_NoCache verifies the runner errors clearly when no cache exists.
+func TestChatFindSpace_NoCache(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	cmd := newFindSpaceCmd()
+	cmd.Flags().Set("name", "sales")
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	cmd.RunE(cmd, []string{})
+	w.Close()
+	os.Stdout = oldStdout
+
+	output, _ := io.ReadAll(r)
+	var result map[string]interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("failed to parse output: %v\nraw: %s", err, output)
+	}
+	if msg, _ := result["error"].(string); msg == "" {
+		t.Errorf("expected error in output, got %v", result)
 	}
 }
 

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -3292,6 +3292,109 @@ func TestChatFindSpace_InvalidType(t *testing.T) {
 	}
 }
 
+// TestChatFindSpace_RefreshTypeScoped drives runChatFindSpace --refresh --type SPACE
+// against a mock spaces.list + members.list. It proves three things end-to-end:
+//   - the refresh path rebuilds the cache from spaces.list rather than relying on
+//     a pre-existing cache file
+//   - --type filters spaces.list scoping (verified via captured Filter param)
+//   - a space whose members.list call fails is still discoverable by display
+//     name through the command path (metadata-only retention)
+func TestChatFindSpace_RefreshTypeScoped(t *testing.T) {
+	tmpHome := t.TempDir()
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpHome)
+	defer os.Setenv("HOME", origHome)
+
+	var capturedListFilter string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/spaces", func(w http.ResponseWriter, r *http.Request) {
+		capturedListFilter = r.URL.Query().Get("filter")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"spaces": []map[string]interface{}{
+				{"name": "spaces/AAA", "spaceType": "SPACE", "displayName": "Sales Skills"},
+				{"name": "spaces/BBB", "spaceType": "SPACE", "displayName": "Sales lunch crew"},
+			},
+		})
+	})
+	mux.HandleFunc("/v1/spaces/AAA/members", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"memberships": []map[string]interface{}{
+				{"name": "spaces/AAA/members/1", "member": map[string]interface{}{"name": "users/111", "type": "HUMAN"}},
+			},
+		})
+	})
+	mux.HandleFunc("/v1/spaces/BBB/members", func(w http.ResponseWriter, r *http.Request) {
+		// Member listing fails for BBB — must still be present as metadata-only.
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"error": "forbidden"})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	chatSvc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+	chatServiceForTest = chatSvc
+	peopleServiceForTest = nil // Build's people calls are best-effort and can be nil
+	defer func() {
+		chatServiceForTest = nil
+		peopleServiceForTest = nil
+	}()
+
+	cmd := newFindSpaceCmd()
+	_ = cmd.Flags().Set("name", "sales")
+	_ = cmd.Flags().Set("type", "SPACE")
+	_ = cmd.Flags().Set("refresh", "true")
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		os.Stdout = oldStdout
+		t.Fatalf("runChatFindSpace returned error: %v", err)
+	}
+	w.Close()
+	os.Stdout = oldStdout
+	output, _ := io.ReadAll(r)
+
+	if capturedListFilter != `spaceType = "SPACE"` {
+		t.Errorf("expected spaces.list filter scoped to SPACE, got %q", capturedListFilter)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("failed to parse stdout: %v\nraw: %s", err, output)
+	}
+	count, _ := result["count"].(float64)
+	if int(count) != 2 {
+		t.Fatalf("expected 2 matches (resolved + metadata-only), got %v\nraw: %s", count, output)
+	}
+	matches, _ := result["matches"].([]interface{})
+	gotNames := map[string]bool{}
+	for _, m := range matches {
+		row, _ := m.(map[string]interface{})
+		if s, _ := row["space"].(string); s != "" {
+			gotNames[s] = true
+		}
+	}
+	if !gotNames["spaces/AAA"] {
+		t.Error("expected spaces/AAA in matches")
+	}
+	if !gotNames["spaces/BBB"] {
+		t.Error("expected spaces/BBB (metadata-only after member fetch failure) in matches")
+	}
+
+	// Cache file should have been written to the temp HOME.
+	cached, err := spacecache.Load(spacecache.DefaultPath())
+	if err != nil {
+		t.Fatalf("failed to load cache after refresh: %v", err)
+	}
+	if entry, ok := cached.Spaces["spaces/BBB"]; !ok || !entry.MembersUnresolved {
+		t.Errorf("expected spaces/BBB in cache with MembersUnresolved=true; got %+v (ok=%v)", entry, ok)
+	}
+}
+
 // TestChatFindSpace_NoCache verifies the runner errors clearly when no cache exists.
 func TestChatFindSpace_NoCache(t *testing.T) {
 	tmpHome := t.TempDir()

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -548,6 +548,7 @@ func TestChatCommands(t *testing.T) {
 		{"event"},
 		{"build-cache"},
 		{"find-group"},
+		{"find-space"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -262,7 +262,7 @@ func TestCalendarCreateCommand_Flags(t *testing.T) {
 		t.Fatal("calendar create command not found")
 	}
 
-	flags := []string{"title", "start", "end", "attendees", "description", "calendar-id"}
+	flags := []string{"title", "start", "end", "attendees", "description", "calendar-id", "add-self"}
 	for _, flag := range flags {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("expected --%s flag", flag)

--- a/internal/spacecache/cache.go
+++ b/internal/spacecache/cache.go
@@ -84,6 +84,31 @@ func FindByMembers(cache *CacheData, emails []string) map[string]SpaceEntry {
 	return results
 }
 
+// FindByDisplayName returns spaces whose display_name contains the (case-insensitive)
+// query substring. If spaceType is non-empty, results are filtered to that type
+// (e.g. "SPACE", "GROUP_CHAT", "DIRECT_MESSAGE"). Spaces without a display_name
+// (typically DMs) are skipped.
+func FindByDisplayName(cache *CacheData, query, spaceType string) map[string]SpaceEntry {
+	results := make(map[string]SpaceEntry)
+	if cache == nil || query == "" {
+		return results
+	}
+	needle := strings.ToLower(query)
+	wantType := strings.ToUpper(spaceType)
+	for name, entry := range cache.Spaces {
+		if entry.DisplayName == "" {
+			continue
+		}
+		if wantType != "" && strings.ToUpper(entry.Type) != wantType {
+			continue
+		}
+		if strings.Contains(strings.ToLower(entry.DisplayName), needle) {
+			results[name] = entry
+		}
+	}
+	return results
+}
+
 // Build iterates spaces, fetches members, resolves emails, and saves the cache.
 // spaceTypeFilter can be "GROUP_CHAT", "SPACE", "DIRECT_MESSAGE", or "all".
 // progress is called with (current, total) for progress reporting (may be nil).

--- a/internal/spacecache/cache.go
+++ b/internal/spacecache/cache.go
@@ -20,6 +20,11 @@ type SpaceEntry struct {
 	DisplayName string   `json:"display_name,omitempty"`
 	Members     []string `json:"members"`
 	MemberCount int      `json:"member_count"`
+	// MembersUnresolved is true when the space appeared in spaces.list but the
+	// member-listing call failed (or was paginated and a later page failed).
+	// Display-name search still matches these entries; member-based search must
+	// skip them since the member list is incomplete.
+	MembersUnresolved bool `json:"members_unresolved,omitempty"`
 }
 
 // CacheData is the on-disk format for the space-members cache.
@@ -73,10 +78,15 @@ func Save(path string, cache *CacheData) error {
 	return os.Rename(tmp, path)
 }
 
-// FindByMembers returns spaces where ALL specified emails are members.
+// FindByMembers returns spaces where ALL specified emails are members. Entries
+// flagged MembersUnresolved are skipped because their member list is incomplete
+// and a positive match cannot be claimed honestly.
 func FindByMembers(cache *CacheData, emails []string) map[string]SpaceEntry {
 	results := make(map[string]SpaceEntry)
 	for name, entry := range cache.Spaces {
+		if entry.MembersUnresolved {
+			continue
+		}
 		if containsAll(entry.Members, emails) {
 			results[name] = entry
 		}
@@ -172,8 +182,17 @@ func Build(ctx context.Context, chatSvc *chat.Service, peopleSvc *people.Service
 			memberPageToken = mResp.NextPageToken
 		}
 
-		// Skip spaces where member fetch failed to avoid partial/incorrect caches
+		// When member fetch fails, retain space metadata so display-name search
+		// can still find it. Member-based search filters these via
+		// MembersUnresolved to avoid partial/incorrect matches.
 		if memberFetchFailed {
+			cache.Spaces[space.Name] = SpaceEntry{
+				Type:              space.SpaceType,
+				DisplayName:       space.DisplayName,
+				Members:           nil,
+				MemberCount:       0,
+				MembersUnresolved: true,
+			}
 			continue
 		}
 

--- a/internal/spacecache/cache_test.go
+++ b/internal/spacecache/cache_test.go
@@ -282,14 +282,26 @@ func TestBuild_SkipsSpaceOnMemberFetchFailure(t *testing.T) {
 		t.Fatalf("Build failed: %v", err)
 	}
 
-	// spaces/FAIL should be skipped (0 members due to error)
-	if _, ok := cache.Spaces["spaces/FAIL"]; ok {
-		t.Error("expected spaces/FAIL to be skipped due to member fetch failure")
+	// spaces/FAIL is retained as a metadata-only entry so display-name search can
+	// still find it. Member-based search must skip it via MembersUnresolved.
+	failEntry, ok := cache.Spaces["spaces/FAIL"]
+	if !ok {
+		t.Fatal("expected spaces/FAIL to remain in cache as metadata-only entry")
+	}
+	if !failEntry.MembersUnresolved {
+		t.Error("spaces/FAIL: expected MembersUnresolved=true")
+	}
+	if len(failEntry.Members) != 0 {
+		t.Errorf("spaces/FAIL: expected empty members, got %v", failEntry.Members)
 	}
 
-	// spaces/OK should be present
-	if _, ok := cache.Spaces["spaces/OK"]; !ok {
-		t.Error("expected spaces/OK to be in cache")
+	// spaces/OK should be present and fully resolved
+	okEntry, ok := cache.Spaces["spaces/OK"]
+	if !ok {
+		t.Fatal("expected spaces/OK to be in cache")
+	}
+	if okEntry.MembersUnresolved {
+		t.Error("spaces/OK: MembersUnresolved must be false")
 	}
 }
 
@@ -337,9 +349,18 @@ func TestBuild_SkipsSpaceOnPartialPageFailure(t *testing.T) {
 		t.Fatalf("Build failed: %v", err)
 	}
 
-	// Space should be skipped entirely — partial member list is unreliable
-	if _, ok := cache.Spaces["spaces/PARTIAL"]; ok {
-		t.Error("expected spaces/PARTIAL to be skipped due to partial page failure")
+	// Partial page failure is treated like full failure: the entry is retained
+	// as metadata-only with MembersUnresolved=true, so member search filters it
+	// out while display-name search can still match.
+	entry, ok := cache.Spaces["spaces/PARTIAL"]
+	if !ok {
+		t.Fatal("expected spaces/PARTIAL to remain in cache as metadata-only entry")
+	}
+	if !entry.MembersUnresolved {
+		t.Error("spaces/PARTIAL: expected MembersUnresolved=true")
+	}
+	if len(entry.Members) != 0 {
+		t.Errorf("spaces/PARTIAL: expected empty members, got %v", entry.Members)
 	}
 }
 
@@ -396,4 +417,36 @@ func keysOf(m map[string]SpaceEntry) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestFindByDisplayName_FindsMetadataOnly verifies that a space whose member
+// list could not be resolved is still discoverable by display-name search.
+func TestFindByDisplayName_FindsMetadataOnly(t *testing.T) {
+	cache := &CacheData{
+		Spaces: map[string]SpaceEntry{
+			"spaces/A": {Type: "SPACE", DisplayName: "Sales Skills", MembersUnresolved: true},
+		},
+	}
+	got := FindByDisplayName(cache, "sales", "")
+	if _, ok := got["spaces/A"]; !ok {
+		t.Errorf("expected spaces/A (metadata-only) to be found by display name; got %v", keysOf(got))
+	}
+}
+
+// TestFindByMembers_SkipsMembersUnresolved verifies member-based search ignores
+// metadata-only entries even if they would coincidentally match.
+func TestFindByMembers_SkipsMembersUnresolved(t *testing.T) {
+	cache := &CacheData{
+		Spaces: map[string]SpaceEntry{
+			"spaces/UNRESOLVED": {Type: "SPACE", DisplayName: "X", Members: nil, MembersUnresolved: true},
+			"spaces/RESOLVED":   {Type: "SPACE", DisplayName: "Y", Members: []string{"alice@example.com"}},
+		},
+	}
+	got := FindByMembers(cache, []string{"alice@example.com"})
+	if _, ok := got["spaces/UNRESOLVED"]; ok {
+		t.Error("spaces/UNRESOLVED must be skipped by FindByMembers")
+	}
+	if _, ok := got["spaces/RESOLVED"]; !ok {
+		t.Error("expected spaces/RESOLVED to match")
+	}
 }

--- a/internal/spacecache/cache_test.go
+++ b/internal/spacecache/cache_test.go
@@ -342,3 +342,58 @@ func TestBuild_SkipsSpaceOnPartialPageFailure(t *testing.T) {
 		t.Error("expected spaces/PARTIAL to be skipped due to partial page failure")
 	}
 }
+
+func TestFindByDisplayName(t *testing.T) {
+	cache := &CacheData{
+		Spaces: map[string]SpaceEntry{
+			"spaces/A": {Type: "SPACE", DisplayName: "Sales Skills", MemberCount: 3},
+			"spaces/B": {Type: "SPACE", DisplayName: "sales-pipeline", MemberCount: 5},
+			"spaces/C": {Type: "GROUP_CHAT", DisplayName: "Sales lunch crew", MemberCount: 4},
+			"spaces/D": {Type: "SPACE", DisplayName: "Engineering", MemberCount: 12},
+			"spaces/E": {Type: "DIRECT_MESSAGE", DisplayName: "", MemberCount: 2},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		query     string
+		spaceType string
+		want      []string
+	}{
+		{"substring case insensitive", "sales", "", []string{"spaces/A", "spaces/B", "spaces/C"}},
+		{"prefix match", "Sales Skills", "", []string{"spaces/A"}},
+		{"type filter SPACE", "sales", "SPACE", []string{"spaces/A", "spaces/B"}},
+		{"type filter lowercase", "sales", "space", []string{"spaces/A", "spaces/B"}},
+		{"type filter GROUP_CHAT", "sales", "GROUP_CHAT", []string{"spaces/C"}},
+		{"no match", "missing", "", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FindByDisplayName(cache, tc.query, tc.spaceType)
+			if len(got) != len(tc.want) {
+				t.Fatalf("expected %d match(es), got %d (%v)", len(tc.want), len(got), keysOf(got))
+			}
+			for _, w := range tc.want {
+				if _, ok := got[w]; !ok {
+					t.Errorf("expected %s in results, got %v", w, keysOf(got))
+				}
+			}
+		})
+	}
+
+	if got := FindByDisplayName(cache, "", ""); len(got) != 0 {
+		t.Errorf("empty query: expected 0 results, got %d", len(got))
+	}
+	if got := FindByDisplayName(nil, "x", ""); len(got) != 0 {
+		t.Errorf("nil cache: expected empty result, got %v", got)
+	}
+}
+
+func keysOf(m map[string]SpaceEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/plugins/gws/skills/calendar/SKILL.md
+++ b/plugins/gws/skills/calendar/SKILL.md
@@ -151,6 +151,7 @@ gws calendar create --title <title> --start <time> --end <time> [flags]
 - `--description string` -- Event description
 - `--location string` -- Event location
 - `--attendees strings` -- Attendee email addresses
+- `--add-self bool` (default `true`) -- Add the authenticated user as an `accepted` attendee. Pass `--add-self=false` to opt out.
 
 ### quick-add -- Quick add from text
 

--- a/plugins/gws/skills/calendar/references/commands.md
+++ b/plugins/gws/skills/calendar/references/commands.md
@@ -137,6 +137,7 @@ Usage: gws calendar create [flags]
 | `--description` | string | | No | Event description |
 | `--location` | string | | No | Event location |
 | `--attendees` | strings | | No | Attendee email addresses (repeatable) |
+| `--add-self` | bool | `true` | No | Add the authenticated user as an `accepted` attendee. Pass `--add-self=false` to opt out. |
 
 ### Time Format
 

--- a/plugins/gws/skills/chat/SKILL.md
+++ b/plugins/gws/skills/chat/SKILL.md
@@ -50,6 +50,7 @@ For initial setup, see the `gws-auth` skill.
 | Create group chat | `gws chat setup-space --type GROUP_CHAT --members "users/1,users/2"` |
 | Build member cache | `gws chat build-cache` |
 | Find group by members | `gws chat find-group --members "user1@example.com,user2@example.com"` |
+| Find space by name | `gws chat find-space --name "sales-skills"` |
 | **Messages** | |
 | Read messages | `gws chat messages <space-id>` |
 | Read recent messages | `gws chat messages <space-id> --order-by "createTime DESC" --max 10` |
@@ -401,6 +402,21 @@ Searches the local space-members cache for spaces where ALL specified emails are
 
 **Flags:**
 - `--members string` — Comma-separated email addresses to search for (required)
+- `--refresh` — Rebuild cache before searching
+
+### find-space — Find spaces by display name
+
+```bash
+gws chat find-space --name "sales-skills"
+gws chat find-space --name "team" --type SPACE
+gws chat find-space --name "lunch" --refresh
+```
+
+Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). Requires `build-cache` to be run first (or use `--refresh`). DMs without a display name are skipped.
+
+**Flags:**
+- `--name string` — Display name substring to search for (case-insensitive, required)
+- `--type string` — Filter by space type: SPACE, GROUP_CHAT, or DIRECT_MESSAGE
 - `--refresh` — Rebuild cache before searching
 
 ## Output Modes

--- a/plugins/gws/skills/chat/SKILL.md
+++ b/plugins/gws/skills/chat/SKILL.md
@@ -407,17 +407,20 @@ Searches the local space-members cache for spaces where ALL specified emails are
 ### find-space — Find spaces by display name
 
 ```bash
-gws chat find-space --name "sales-skills"
+gws chat find-space --name "sales-skills" --refresh
 gws chat find-space --name "team" --type SPACE
-gws chat find-space --name "lunch" --refresh
 ```
 
-Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). Requires `build-cache` to be run first (or use `--refresh`). DMs without a display name are skipped.
+Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). DMs without a display name are skipped.
+
+**Cache scope matters.** Default `gws chat build-cache` only caches `GROUP_CHAT`. To find `SPACE`-type rooms (most named spaces) or all types, either:
+- prebuild with `gws chat build-cache --type SPACE` (or `--type all`), or
+- pass `--refresh` so this command rebuilds the cache before searching.
 
 **Flags:**
 - `--name string` — Display name substring to search for (case-insensitive, required)
 - `--type string` — Filter by space type: SPACE, GROUP_CHAT, or DIRECT_MESSAGE
-- `--refresh` — Rebuild cache before searching
+- `--refresh` — Rebuild cache before searching (scoped to `--type` if set, otherwise all types)
 
 ## Output Modes
 

--- a/plugins/gws/skills/chat/references/commands.md
+++ b/plugins/gws/skills/chat/references/commands.md
@@ -545,7 +545,7 @@ Usage: gws chat find-space [flags]
 
 ### Output Fields (JSON)
 
-- `matches` — Array of matching spaces with `space`, `type`, `display_name`, `member_count`
+- `matches` — Array of matching spaces, sorted by `display_name` then `space`. Each entry has `space`, `type`, `display_name`, `member_count`. When the cache could not resolve a space's member list, the entry also carries `members_unresolved: true` (and `member_count: 0`); display-name search still surfaces it, but member-based search will skip it.
 - `count` — Number of matching spaces
 - `query` — The display-name substring searched for
 - `type` — The type filter (only present when `--type` is set)

--- a/plugins/gws/skills/chat/references/commands.md
+++ b/plugins/gws/skills/chat/references/commands.md
@@ -522,3 +522,28 @@ Usage: gws chat find-group [flags]
 - `matches` — Array of matching spaces with `space`, `type`, `display_name`, `members`, `member_count`
 - `count` — Number of matching spaces
 - `query` — The email addresses searched for
+
+---
+
+## gws chat find-space
+
+Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). Requires `build-cache` to be run first (or pass `--refresh`).
+
+```
+Usage: gws chat find-space [flags]
+```
+
+### Flags
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--name` | string | | Yes | Display name substring to search for (case-insensitive) |
+| `--type` | string | | No | Filter by space type: SPACE, GROUP_CHAT, or DIRECT_MESSAGE |
+| `--refresh` | bool | false | No | Rebuild cache before searching |
+
+### Output Fields (JSON)
+
+- `matches` — Array of matching spaces with `space`, `type`, `display_name`, `member_count`
+- `count` — Number of matching spaces
+- `query` — The display-name substring searched for
+- `type` — The type filter (only present when `--type` is set)

--- a/plugins/gws/skills/chat/references/commands.md
+++ b/plugins/gws/skills/chat/references/commands.md
@@ -527,7 +527,9 @@ Usage: gws chat find-group [flags]
 
 ## gws chat find-space
 
-Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). Requires `build-cache` to be run first (or pass `--refresh`).
+Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match).
+
+**Cache scope.** Default `gws chat build-cache` caches only `GROUP_CHAT`. To find `SPACE`-type rooms or all types, either prebuild with `gws chat build-cache --type SPACE` (or `--type all`), or pass `--refresh` to rebuild the cache from `spaces.list` before searching. When `--refresh` is set together with `--type`, the cache is rebuilt scoped to that type only.
 
 ```
 Usage: gws chat find-space [flags]

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -152,6 +152,7 @@ gws calendar create --title <title> --start <time> --end <time> [flags]
 - `--description string` -- Event description
 - `--location string` -- Event location
 - `--attendees strings` -- Attendee email addresses
+- `--add-self bool` (default `true`) -- Add the authenticated user as an `accepted` attendee. Pass `--add-self=false` to opt out.
 
 ### quick-add -- Quick add from text
 

--- a/skills/calendar/references/commands.md
+++ b/skills/calendar/references/commands.md
@@ -137,6 +137,7 @@ Usage: gws calendar create [flags]
 | `--description` | string | | No | Event description |
 | `--location` | string | | No | Event location |
 | `--attendees` | strings | | No | Attendee email addresses (repeatable) |
+| `--add-self` | bool | `true` | No | Add the authenticated user as an `accepted` attendee. Pass `--add-self=false` to opt out. |
 
 ### Time Format
 

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -408,17 +408,20 @@ Searches the local space-members cache for spaces where ALL specified emails are
 ### find-space — Find spaces by display name
 
 ```bash
-gws chat find-space --name "sales-skills"
+gws chat find-space --name "sales-skills" --refresh
 gws chat find-space --name "team" --type SPACE
-gws chat find-space --name "lunch" --refresh
 ```
 
-Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). Requires `build-cache` to be run first (or use `--refresh`). DMs without a display name are skipped.
+Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). DMs without a display name are skipped.
+
+**Cache scope matters.** Default `gws chat build-cache` only caches `GROUP_CHAT`. To find `SPACE`-type rooms (most named spaces) or all types, either:
+- prebuild with `gws chat build-cache --type SPACE` (or `--type all`), or
+- pass `--refresh` so this command rebuilds the cache before searching.
 
 **Flags:**
 - `--name string` — Display name substring to search for (case-insensitive, required)
 - `--type string` — Filter by space type: SPACE, GROUP_CHAT, or DIRECT_MESSAGE
-- `--refresh` — Rebuild cache before searching
+- `--refresh` — Rebuild cache before searching (scoped to `--type` if set, otherwise all types)
 
 ## Output Modes
 

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -51,6 +51,7 @@ For initial setup, see the `gws-auth` skill.
 | Create group chat | `gws chat setup-space --type GROUP_CHAT --members "users/1,users/2"` |
 | Build member cache | `gws chat build-cache` |
 | Find group by members | `gws chat find-group --members "user1@example.com,user2@example.com"` |
+| Find space by name | `gws chat find-space --name "sales-skills"` |
 | **Messages** | |
 | Read messages | `gws chat messages <space-id>` |
 | Read recent messages | `gws chat messages <space-id> --order-by "createTime DESC" --max 10` |
@@ -402,6 +403,21 @@ Searches the local space-members cache for spaces where ALL specified emails are
 
 **Flags:**
 - `--members string` — Comma-separated email addresses to search for (required)
+- `--refresh` — Rebuild cache before searching
+
+### find-space — Find spaces by display name
+
+```bash
+gws chat find-space --name "sales-skills"
+gws chat find-space --name "team" --type SPACE
+gws chat find-space --name "lunch" --refresh
+```
+
+Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). Requires `build-cache` to be run first (or use `--refresh`). DMs without a display name are skipped.
+
+**Flags:**
+- `--name string` — Display name substring to search for (case-insensitive, required)
+- `--type string` — Filter by space type: SPACE, GROUP_CHAT, or DIRECT_MESSAGE
 - `--refresh` — Rebuild cache before searching
 
 ## Output Modes

--- a/skills/chat/references/commands.md
+++ b/skills/chat/references/commands.md
@@ -545,7 +545,7 @@ Usage: gws chat find-space [flags]
 
 ### Output Fields (JSON)
 
-- `matches` — Array of matching spaces with `space`, `type`, `display_name`, `member_count`
+- `matches` — Array of matching spaces, sorted by `display_name` then `space`. Each entry has `space`, `type`, `display_name`, `member_count`. When the cache could not resolve a space's member list, the entry also carries `members_unresolved: true` (and `member_count: 0`); display-name search still surfaces it, but member-based search will skip it.
 - `count` — Number of matching spaces
 - `query` — The display-name substring searched for
 - `type` — The type filter (only present when `--type` is set)

--- a/skills/chat/references/commands.md
+++ b/skills/chat/references/commands.md
@@ -522,3 +522,28 @@ Usage: gws chat find-group [flags]
 - `matches` — Array of matching spaces with `space`, `type`, `display_name`, `members`, `member_count`
 - `count` — Number of matching spaces
 - `query` — The email addresses searched for
+
+---
+
+## gws chat find-space
+
+Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). Requires `build-cache` to be run first (or pass `--refresh`).
+
+```
+Usage: gws chat find-space [flags]
+```
+
+### Flags
+
+| Flag | Type | Default | Required | Description |
+|------|------|---------|----------|-------------|
+| `--name` | string | | Yes | Display name substring to search for (case-insensitive) |
+| `--type` | string | | No | Filter by space type: SPACE, GROUP_CHAT, or DIRECT_MESSAGE |
+| `--refresh` | bool | false | No | Rebuild cache before searching |
+
+### Output Fields (JSON)
+
+- `matches` — Array of matching spaces with `space`, `type`, `display_name`, `member_count`
+- `count` — Number of matching spaces
+- `query` — The display-name substring searched for
+- `type` — The type filter (only present when `--type` is set)

--- a/skills/chat/references/commands.md
+++ b/skills/chat/references/commands.md
@@ -527,7 +527,9 @@ Usage: gws chat find-group [flags]
 
 ## gws chat find-space
 
-Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match). Requires `build-cache` to be run first (or pass `--refresh`).
+Searches the local space cache for spaces whose `display_name` contains the given query (case-insensitive substring match).
+
+**Cache scope.** Default `gws chat build-cache` caches only `GROUP_CHAT`. To find `SPACE`-type rooms or all types, either prebuild with `gws chat build-cache --type SPACE` (or `--type all`), or pass `--refresh` to rebuild the cache from `spaces.list` before searching. When `--refresh` is set together with `--type`, the cache is rebuilt scoped to that type only.
 
 ```
 Usage: gws chat find-space [flags]


### PR DESCRIPTION
## Summary

Three core items for v1.36.0, scoped by CTO:

- **#171 — chat attachment metadata.** `gws chat messages`, `gws chat get`, and `gws chat unread` now include an `attachment[]` field with `name`, `content_name`, `content_type`, `source`, `download_uri`, `thumbnail_uri`, and the `attachment_data_ref.resource_name` needed by `gws chat attachment` / `gws chat download`. Closes the broken chain that was forcing fallbacks to raw curl.
- **#176 — calendar self-attendee.** `gws calendar events create` now adds the authenticated user as an `accepted` attendee with `self: true` by default. Opt-out via `--add-self=false`. The user's primary email is resolved via `Calendars.Get(\"primary\")`. If the user already passed themselves in `--attendees`, no duplicate row is added (case-insensitive match).
- **#170 — chat find-space via cache.** New `gws chat find-space --name <substring>` searches the existing space cache by `display_name` (case-insensitive). Supports `--type SPACE|GROUP_CHAT|DIRECT_MESSAGE` and `--refresh`. The cache schema already had `display_name`, so no migration is needed.

Excluded from this pass: #175 (sender attribution; deferred to a notes-only spike after this lands), #174, #104, and older infra/new-service tracks. #164 and #172 have been closed as already addressed.

Also adds `.agent-mail/` and `.amq-squad/` to `.gitignore` for local AMQ coordination dirs.

## Test plan

- [x] `make test` — all packages pass locally
- [x] Unit tests for `serializeChatAttachments` (empty, all-fields, drops-empty-entries)
- [x] Unit tests for `attendeeListContainsEmail` (case-insensitive, nil tolerance)
- [x] Mock-server tests for `getSelfCalendarEmail` and the `--add-self` insert flow (server captures payload, asserts self email + accepted + self=true)
- [x] Unit tests for `spacecache.FindByDisplayName` (substring, case-insensitive, type filter, empty query, nil cache)
- [x] Runner-level tests for `find-space` matches, `--type` filter, invalid type, and missing-cache error
- [x] `find-space` registered in `TestChatCommands` subcommand list
- [ ] Manual smoke test (deferred to post-review since this would require a live OAuth session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)