### PR TITLE
fix(drive): resolve/unresolve via Replies.Create action (#179)

### DIFF
--- a/cmd/drive.go
+++ b/cmd/drive.go
@@ -277,15 +277,19 @@ var driveDeleteCommentCmd = &cobra.Command{
 var driveResolveCommentCmd = &cobra.Command{
 	Use:   "resolve-comment",
 	Short: "Resolve a comment",
-	Long:  "Marks a comment on a Google Drive file as resolved.",
-	RunE:  runDriveResolveComment,
+	Long: "Marks a comment on a Google Drive file as resolved by posting a reply " +
+		"with action=resolve. Optional --content attaches a closing note; the " +
+		"original comment content is never modified.",
+	RunE: runDriveResolveComment,
 }
 
 var driveUnresolveCommentCmd = &cobra.Command{
 	Use:   "unresolve-comment",
 	Short: "Unresolve a comment",
-	Long:  "Marks a comment on a Google Drive file as unresolved.",
-	RunE:  runDriveUnresolveComment,
+	Long: "Reopens a previously resolved comment by posting a reply with " +
+		"action=reopen. Optional --content attaches a reopening note; the " +
+		"original comment content is never modified.",
+	RunE: runDriveUnresolveComment,
 }
 
 // --- Files ---
@@ -572,11 +576,13 @@ func init() {
 	// Resolve/Unresolve comment flags
 	driveResolveCommentCmd.Flags().String("file-id", "", "File ID (required)")
 	driveResolveCommentCmd.Flags().String("comment-id", "", "Comment ID (required)")
+	driveResolveCommentCmd.Flags().String("content", "", "Optional closing note attached to the resolve reply")
 	driveResolveCommentCmd.MarkFlagRequired("file-id")
 	driveResolveCommentCmd.MarkFlagRequired("comment-id")
 
 	driveUnresolveCommentCmd.Flags().String("file-id", "", "File ID (required)")
 	driveUnresolveCommentCmd.Flags().String("comment-id", "", "Comment ID (required)")
+	driveUnresolveCommentCmd.Flags().String("content", "", "Optional reopening note attached to the reopen reply")
 	driveUnresolveCommentCmd.MarkFlagRequired("file-id")
 	driveUnresolveCommentCmd.MarkFlagRequired("comment-id")
 
@@ -2144,43 +2150,45 @@ func runDriveSetCommentResolved(cmd *cobra.Command, resolved bool) error {
 
 	fileID, _ := cmd.Flags().GetString("file-id")
 	commentID, _ := cmd.Flags().GetString("comment-id")
+	content, _ := cmd.Flags().GetString("content")
 
-	comment := &drive.Comment{
-		Resolved:        resolved,
-		ForceSendFields: []string{"Resolved"},
-	}
-
-	updated, err := svc.Comments.Update(fileID, commentID, comment).
-		Fields("id,content,resolved,modifiedTime,author(displayName,emailAddress)").
-		Do()
-	if err != nil {
-		action := "resolve"
-		if !resolved {
-			action = "unresolve"
-		}
-		return p.PrintError(fmt.Errorf("failed to %s comment: %w", action, err))
-	}
-
+	action := "resolve"
 	status := "resolved"
 	if !resolved {
+		action = "reopen"
 		status = "unresolved"
 	}
 
+	reply := &drive.Reply{
+		Action:  action,
+		Content: content,
+	}
+
+	created, err := svc.Replies.Create(fileID, commentID, reply).
+		Fields("id,action,content,createdTime,author(displayName,emailAddress)").
+		Do()
+	if err != nil {
+		return p.PrintError(fmt.Errorf("failed to %s comment: %w", action, err))
+	}
+
 	result := map[string]interface{}{
-		"status":   status,
-		"id":       updated.Id,
-		"resolved": updated.Resolved,
+		"status":     status,
+		"file_id":    fileID,
+		"comment_id": commentID,
+		"reply_id":   created.Id,
+		"action":     created.Action,
+		"resolved":   resolved,
 	}
-	if updated.Content != "" {
-		result["content"] = updated.Content
+	if created.Content != "" {
+		result["content"] = created.Content
 	}
-	if updated.ModifiedTime != "" {
-		result["modified"] = updated.ModifiedTime
+	if created.CreatedTime != "" {
+		result["created"] = created.CreatedTime
 	}
-	if updated.Author != nil {
+	if created.Author != nil {
 		result["author"] = map[string]interface{}{
-			"name":  updated.Author.DisplayName,
-			"email": updated.Author.EmailAddress,
+			"name":  created.Author.DisplayName,
+			"email": created.Author.EmailAddress,
 		}
 	}
 

--- a/cmd/drive_test.go
+++ b/cmd/drive_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"google.golang.org/api/drive/v3"
@@ -2411,7 +2412,7 @@ func TestDriveActivity_MutualExclusivity(t *testing.T) {
 
 func TestDriveResolveCommentCommand_Flags(t *testing.T) {
 	cmd := driveResolveCommentCmd
-	flags := []string{"file-id", "comment-id"}
+	flags := []string{"file-id", "comment-id", "content"}
 	for _, flag := range flags {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("expected --%s flag", flag)
@@ -2421,7 +2422,7 @@ func TestDriveResolveCommentCommand_Flags(t *testing.T) {
 
 func TestDriveUnresolveCommentCommand_Flags(t *testing.T) {
 	cmd := driveUnresolveCommentCmd
-	flags := []string{"file-id", "comment-id"}
+	flags := []string{"file-id", "comment-id", "content"}
 	for _, flag := range flags {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("expected --%s flag", flag)
@@ -2429,37 +2430,39 @@ func TestDriveUnresolveCommentCommand_Flags(t *testing.T) {
 	}
 }
 
-func TestDriveResolveComment_MockServer(t *testing.T) {
-	resolveCalled := false
+// Issue #179: resolve/unresolve must hit Replies.Create with action=resolve|reopen,
+// not Comments.Update — the latter rejects the request with
+// "Comment content is required." and would also overwrite the original comment.
+
+func TestDriveResolveComment_PostsResolveReply(t *testing.T) {
+	var (
+		called  bool
+		gotPath string
+		gotBody drive.Reply
+	)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		if r.URL.Path == "/files/test-file-id/comments/comment-1" && r.Method == "PATCH" {
-			resolveCalled = true
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/comments/comment-1/replies") {
+			called = true
+			gotPath = r.URL.Path
+			json.NewDecoder(r.Body).Decode(&gotBody)
 
-			var comment drive.Comment
-			json.NewDecoder(r.Body).Decode(&comment)
-
-			if !comment.Resolved {
-				t.Error("expected Resolved to be true")
-			}
-
-			resp := &drive.Comment{
-				Id:           "comment-1",
-				Content:      "Test comment",
-				Resolved:     true,
-				ModifiedTime: "2024-01-15T12:00:00Z",
+			json.NewEncoder(w).Encode(&drive.Reply{
+				Id:          "reply-1",
+				Action:      "resolve",
+				Content:     gotBody.Content,
+				CreatedTime: "2026-04-30T12:00:00Z",
 				Author: &drive.User{
 					DisplayName:  "Test User",
 					EmailAddress: "test@example.com",
 				},
-			}
-			json.NewEncoder(w).Encode(resp)
+			})
 			return
 		}
 
-		t.Logf("Unexpected request: %s %s", r.Method, r.URL.Path)
+		t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
@@ -2469,45 +2472,41 @@ func TestDriveResolveComment_MockServer(t *testing.T) {
 		t.Fatalf("failed to create drive service: %v", err)
 	}
 
-	comment := &drive.Comment{
-		Resolved:        true,
-		ForceSendFields: []string{"Resolved"},
-	}
-	updated, err := svc.Comments.Update("test-file-id", "comment-1", comment).
-		Fields("id,content,resolved,modifiedTime,author(displayName,emailAddress)").
+	reply := &drive.Reply{Action: "resolve", Content: "lgtm"}
+	created, err := svc.Replies.Create("test-file-id", "comment-1", reply).
+		Fields("id,action,content,createdTime,author(displayName,emailAddress)").
 		Do()
 	if err != nil {
 		t.Fatalf("failed to resolve comment: %v", err)
 	}
 
-	if !updated.Resolved {
-		t.Error("expected comment to be resolved")
+	if !called {
+		t.Fatal("replies endpoint was not called")
 	}
-	if !resolveCalled {
-		t.Error("resolve endpoint was not called")
+	if want := "/files/test-file-id/comments/comment-1/replies"; gotPath != want {
+		t.Errorf("path = %q, want %q", gotPath, want)
+	}
+	if gotBody.Action != "resolve" {
+		t.Errorf("Action = %q, want %q", gotBody.Action, "resolve")
+	}
+	if gotBody.Content != "lgtm" {
+		t.Errorf("Content = %q, want %q", gotBody.Content, "lgtm")
+	}
+	if created.Action != "resolve" {
+		t.Errorf("response Action = %q, want resolve", created.Action)
 	}
 }
 
-func TestDriveUnresolveComment_MockServer(t *testing.T) {
-	unresolveCalled := false
+func TestDriveResolveComment_OmitContentSendsActionOnly(t *testing.T) {
+	var gotBody drive.Reply
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-
-		if r.URL.Path == "/files/test-file-id/comments/comment-1" && r.Method == "PATCH" {
-			unresolveCalled = true
-
-			resp := &drive.Comment{
-				Id:           "comment-1",
-				Content:      "Test comment",
-				Resolved:     false,
-				ModifiedTime: "2024-01-15T13:00:00Z",
-			}
-			json.NewEncoder(w).Encode(resp)
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/replies") {
+			json.NewDecoder(r.Body).Decode(&gotBody)
+			json.NewEncoder(w).Encode(&drive.Reply{Id: "reply-1", Action: "resolve"})
 			return
 		}
-
-		t.Logf("Unexpected request: %s %s", r.Method, r.URL.Path)
 		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer server.Close()
@@ -2517,21 +2516,53 @@ func TestDriveUnresolveComment_MockServer(t *testing.T) {
 		t.Fatalf("failed to create drive service: %v", err)
 	}
 
-	comment := &drive.Comment{
-		Resolved:        false,
-		ForceSendFields: []string{"Resolved"},
-	}
-	updated, err := svc.Comments.Update("test-file-id", "comment-1", comment).
-		Fields("id,content,resolved,modifiedTime").
-		Do()
-	if err != nil {
-		t.Fatalf("failed to unresolve comment: %v", err)
+	if _, err := svc.Replies.Create("test-file-id", "comment-1", &drive.Reply{Action: "resolve"}).Do(); err != nil {
+		t.Fatalf("failed to resolve comment: %v", err)
 	}
 
-	if updated.Resolved {
-		t.Error("expected comment to be unresolved")
+	if gotBody.Action != "resolve" {
+		t.Errorf("Action = %q, want resolve", gotBody.Action)
 	}
-	if !unresolveCalled {
-		t.Error("unresolve endpoint was not called")
+	if gotBody.Content != "" {
+		t.Errorf("Content = %q, want empty (must not overwrite original comment)", gotBody.Content)
+	}
+}
+
+func TestDriveUnresolveComment_PostsReopenReply(t *testing.T) {
+	var (
+		called  bool
+		gotBody drive.Reply
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/comments/comment-1/replies") {
+			called = true
+			json.NewDecoder(r.Body).Decode(&gotBody)
+			json.NewEncoder(w).Encode(&drive.Reply{
+				Id:          "reply-2",
+				Action:      "reopen",
+				CreatedTime: "2026-04-30T13:00:00Z",
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	svc, err := drive.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create drive service: %v", err)
+	}
+
+	if _, err := svc.Replies.Create("test-file-id", "comment-1", &drive.Reply{Action: "reopen"}).Do(); err != nil {
+		t.Fatalf("failed to reopen comment: %v", err)
+	}
+
+	if !called {
+		t.Fatal("replies endpoint was not called")
+	}
+	if gotBody.Action != "reopen" {
+		t.Errorf("Action = %q, want reopen", gotBody.Action)
 	}
 }

--- a/skills/drive/SKILL.md
+++ b/skills/drive/SKILL.md
@@ -339,14 +339,23 @@ gws drive delete-comment --file-id <id> --comment-id <cid>
 
 ### resolve-comment — Resolve a comment
 
+Posts a reply with `action=resolve` (the documented Drive API path for state
+transitions). The original comment content is never modified. Pass an
+optional `--content` to attach a closing note.
+
 ```bash
 gws drive resolve-comment --file-id <id> --comment-id <cid>
+gws drive resolve-comment --file-id <id> --comment-id <cid> --content "fixed in #1234"
 ```
 
-### unresolve-comment — Unresolve a comment
+### unresolve-comment — Reopen a resolved comment
+
+Posts a reply with `action=reopen`. The original comment content is never
+modified. Pass an optional `--content` to attach a reopening note.
 
 ```bash
 gws drive unresolve-comment --file-id <id> --comment-id <cid>
+gws drive unresolve-comment --file-id <id> --comment-id <cid> --content "still broken on safari"
 ```
 
 ### replies — List replies

--- a/skills/drive/references/commands.md
+++ b/skills/drive/references/commands.md
@@ -409,7 +409,8 @@ Usage: gws drive delete-comment [flags]
 
 ## gws drive resolve-comment
 
-Marks a comment as resolved.
+Marks a comment as resolved by posting a reply with `action=resolve`. The
+original comment content is preserved.
 
 ```
 Usage: gws drive resolve-comment [flags]
@@ -419,12 +420,14 @@ Usage: gws drive resolve-comment [flags]
 |------|------|---------|----------|-------------|
 | `--file-id` | string | | Yes | File ID |
 | `--comment-id` | string | | Yes | Comment ID |
+| `--content` | string | | No | Optional closing note attached to the resolve reply |
 
 ---
 
 ## gws drive unresolve-comment
 
-Marks a comment as unresolved.
+Reopens a resolved comment by posting a reply with `action=reopen`. The
+original comment content is preserved.
 
 ```
 Usage: gws drive unresolve-comment [flags]
@@ -434,6 +437,7 @@ Usage: gws drive unresolve-comment [flags]
 |------|------|---------|----------|-------------|
 | `--file-id` | string | | Yes | File ID |
 | `--comment-id` | string | | Yes | Comment ID |
+| `--content` | string | | No | Optional reopening note attached to the reopen reply |
 
 ---
 


### PR DESCRIPTION
Closes #179. Supersedes #180.

## Summary

`gws drive resolve-comment` / `unresolve-comment` were calling
`Comments.Update` with only `Resolved` set, which the Drive API rejects
with `400: Comment content is required.`. The natural fix — supplying a
default `Content` on the comment update — works at the wire level but
**overwrites the original comment body**, which is wrong.

The documented Drive API path for state transitions is
`Replies.Create` with `action=resolve` or `action=reopen`. That posts a
small reply that flips the parent comment's resolved state without
touching the original content.

## Changes

- `cmd/drive.go`: switch `runDriveSetCommentResolved` to
  `Replies.Create` with `Action=resolve|reopen`. Add optional
  `--content` flag to attach a closing/reopening note (sent on the reply,
  never on the comment). Output now reports `reply_id`, `action`, and
  the resulting resolved status.
- `cmd/drive_test.go`: replace the old `Comments.Update` mock tests with
  ones that assert `POST /files/{fid}/comments/{cid}/replies` with the
  expected action; add a no-content test that verifies the reply body
  carries `action` only (no `content`, so the original comment is not
  rewritten).
- `skills/drive/SKILL.md` + `skills/drive/references/commands.md`:
  document the new behavior and the optional `--content` flag.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./cmd/ -run "Drive.*Resolve|Drive.*Unresolve" -v` — 6/6 pass
- [x] `go test ./...` — full module passes
- [x] `gofmt -w cmd/drive.go cmd/drive_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)