### PR TITLE
feat(gmail): expose attachment metadata in read/thread (#181)

### DIFF
--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -634,6 +634,12 @@ func runGmailRead(cmd *cobra.Command, args []string) error {
 	// Labels
 	result["labels"] = msg.LabelIds
 
+	// Attachments — surface attachment_id so callers can chain to
+	// `gws gmail attachment --message-id <id> --id <attachment-id>`.
+	if atts := extractAttachments(msg.Payload); len(atts) > 0 {
+		result["attachments"] = atts
+	}
+
 	return p.Print(result)
 }
 
@@ -1149,6 +1155,11 @@ func runGmailThread(cmd *cobra.Command, args []string) error {
 		// Labels
 		msgInfo["labels"] = msg.LabelIds
 
+		// Attachments
+		if atts := extractAttachments(msg.Payload); len(atts) > 0 {
+			msgInfo["attachments"] = atts
+		}
+
 		messages = append(messages, msgInfo)
 	}
 
@@ -1568,6 +1579,38 @@ func emailMatchesSelf(addr string, myEmail string) bool {
 		}
 	}
 	return addr == myEmail
+}
+
+// extractAttachments walks a message payload and returns metadata for every
+// part that carries a Gmail attachment ID. Inline parts that are also
+// presented as downloadable attachments (image references, calendar
+// invites, etc.) are included so callers can pass `attachment_id` to
+// `gws gmail attachment` without needing the web UI.
+func extractAttachments(payload *gmail.MessagePart) []map[string]interface{} {
+	if payload == nil {
+		return nil
+	}
+	var out []map[string]interface{}
+	var walk func(part *gmail.MessagePart)
+	walk = func(part *gmail.MessagePart) {
+		if part == nil {
+			return
+		}
+		if part.Body != nil && part.Body.AttachmentId != "" && part.Filename != "" {
+			out = append(out, map[string]interface{}{
+				"filename":      part.Filename,
+				"mime_type":     part.MimeType,
+				"size":          part.Body.Size,
+				"attachment_id": part.Body.AttachmentId,
+				"part_id":       part.PartId,
+			})
+		}
+		for _, child := range part.Parts {
+			walk(child)
+		}
+	}
+	walk(payload)
+	return out
 }
 
 // extractBody extracts the plain text body from a message payload.

--- a/cmd/gmail_test.go
+++ b/cmd/gmail_test.go
@@ -2782,3 +2782,117 @@ func TestBuildMIMEMessage(t *testing.T) {
 		}
 	})
 }
+
+// --- Issue #181: attachment metadata discoverability ---
+
+func TestExtractAttachments_FlatPayload(t *testing.T) {
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/mixed",
+		Parts: []*gmail.MessagePart{
+			{
+				PartId:   "0",
+				MimeType: "text/plain",
+				Body:     &gmail.MessagePartBody{Data: "aGVsbG8="},
+			},
+			{
+				PartId:   "1",
+				MimeType: "application/pdf",
+				Filename: "resume.pdf",
+				Body: &gmail.MessagePartBody{
+					AttachmentId: "ATT_PDF_1",
+					Size:         12345,
+				},
+			},
+			{
+				PartId:   "2",
+				MimeType: "image/png",
+				Filename: "logo.png",
+				Body: &gmail.MessagePartBody{
+					AttachmentId: "ATT_PNG_2",
+					Size:         678,
+				},
+			},
+		},
+	}
+
+	got := extractAttachments(payload)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 attachments, got %d", len(got))
+	}
+	if got[0]["filename"] != "resume.pdf" || got[0]["attachment_id"] != "ATT_PDF_1" {
+		t.Errorf("first attachment wrong: %+v", got[0])
+	}
+	if got[0]["mime_type"] != "application/pdf" {
+		t.Errorf("mime_type = %v, want application/pdf", got[0]["mime_type"])
+	}
+	if got[0]["size"] != int64(12345) {
+		t.Errorf("size = %v (%T), want int64(12345)", got[0]["size"], got[0]["size"])
+	}
+	if got[1]["filename"] != "logo.png" || got[1]["attachment_id"] != "ATT_PNG_2" {
+		t.Errorf("second attachment wrong: %+v", got[1])
+	}
+}
+
+func TestExtractAttachments_NestedMultipart(t *testing.T) {
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/mixed",
+		Parts: []*gmail.MessagePart{
+			{
+				MimeType: "multipart/alternative",
+				Parts: []*gmail.MessagePart{
+					{MimeType: "text/plain", Body: &gmail.MessagePartBody{Data: "aGk="}},
+					{MimeType: "text/html", Body: &gmail.MessagePartBody{Data: "PGk+"}},
+				},
+			},
+			{
+				MimeType: "application/pdf",
+				Filename: "contract.pdf",
+				Body:     &gmail.MessagePartBody{AttachmentId: "ATT_DEEP", Size: 999},
+			},
+		},
+	}
+
+	got := extractAttachments(payload)
+	if len(got) != 1 || got[0]["attachment_id"] != "ATT_DEEP" {
+		t.Fatalf("expected one nested attachment with id ATT_DEEP, got %+v", got)
+	}
+}
+
+func TestExtractAttachments_NoAttachments(t *testing.T) {
+	payload := &gmail.MessagePart{
+		MimeType: "text/plain",
+		Body:     &gmail.MessagePartBody{Data: "aGVsbG8="},
+	}
+	if got := extractAttachments(payload); len(got) != 0 {
+		t.Errorf("expected no attachments, got %+v", got)
+	}
+	// Nil-safe.
+	if got := extractAttachments(nil); got != nil {
+		t.Errorf("expected nil for nil payload, got %+v", got)
+	}
+}
+
+func TestExtractAttachments_SkipsPartsWithoutAttachmentID(t *testing.T) {
+	// A text/plain body part has data but no AttachmentId — must not be
+	// reported as an attachment. Same for an inline part with a filename
+	// but no AttachmentId (the only handle gws gmail attachment can use).
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/mixed",
+		Parts: []*gmail.MessagePart{
+			{
+				PartId:   "0",
+				MimeType: "text/plain",
+				Body:     &gmail.MessagePartBody{Data: "aGVsbG8="},
+			},
+			{
+				PartId:   "1",
+				MimeType: "image/png",
+				Filename: "inline.png",
+				Body:     &gmail.MessagePartBody{Data: "ZGF0YQ=="},
+			},
+		},
+	}
+	if got := extractAttachments(payload); len(got) != 0 {
+		t.Errorf("expected no attachments, got %+v", got)
+	}
+}

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -104,7 +104,7 @@ gws gmail list --query "label:work" --all
 gws gmail thread <thread-id>
 ```
 
-Reads and displays all messages in a Gmail thread (conversation). Use the `thread_id` from `gws gmail list` output. Returns all messages with headers, body, and labels.
+Reads and displays all messages in a Gmail thread (conversation). Use the `thread_id` from `gws gmail list` output. Returns all messages with headers, body, labels, and `attachments` (when present) — each entry exposes `filename`, `mime_type`, `size`, `attachment_id`, and `part_id`.
 
 ### read — Read a message
 
@@ -112,7 +112,12 @@ Reads and displays all messages in a Gmail thread (conversation). Use the `threa
 gws gmail read <message-id>
 ```
 
-Reads and displays the content of a specific email message. Use the `message_id` from `gws gmail list` output.
+Reads and displays the content of a specific email message. Use the `message_id` from `gws gmail list` output. When the message has attachments, the response includes an `attachments` array. Each entry has `filename`, `mime_type`, `size`, `attachment_id`, and `part_id`; pass `attachment_id` to `gws gmail attachment --id <id>` to download.
+
+```bash
+ATT_ID=$(gws gmail read <msg-id> --format json | jq -r '.attachments[0].attachment_id')
+gws gmail attachment --message-id <msg-id> --id "$ATT_ID" --output file.pdf
+```
 
 ### send — Send an email
 
@@ -455,9 +460,15 @@ gws gmail attachment --message-id <msg-id> --id <attachment-id> --output <file-p
 - `--id string` — Attachment ID (required)
 - `--output string` — Output file path (required)
 
+Discover the `--id` value from the `attachments` array on `gws gmail read` or `gws gmail thread` output. Each entry includes `filename`, `mime_type`, `size`, `attachment_id`, and `part_id`.
+
 **Examples:**
 ```bash
 gws gmail attachment --message-id 18abc123 --id ANGjdJ9x --output report.pdf
+
+# End-to-end: discover the attachment ID and download it.
+ATT_ID=$(gws gmail read 18abc123 --format json | jq -r '.attachments[0].attachment_id')
+gws gmail attachment --message-id 18abc123 --id "$ATT_ID" --output report.pdf
 ```
 
 ## Tips for AI Agents

--- a/skills/gmail/references/commands.md
+++ b/skills/gmail/references/commands.md
@@ -80,6 +80,12 @@ No additional flags. Use the `message_id` from `gws gmail list` output.
 - `headers` — Object with `subject`, `from`, `to`, `date`, `cc`, `bcc`
 - `body` — Message body text
 - `labels` — Applied label IDs
+- `attachments` — Array (omitted when empty). Each entry:
+  - `filename` — Attachment file name
+  - `mime_type` — MIME type
+  - `size` — Size in bytes
+  - `attachment_id` — Pass to `gws gmail attachment --id <id>`
+  - `part_id` — Gmail part identifier
 
 ---
 
@@ -102,6 +108,7 @@ No additional flags. Use the `thread_id` from `gws gmail list` output.
   - `headers` — Object with `subject`, `from`, `to`, `date`, `cc`, `bcc`
   - `body` — Message body text
   - `labels` — Applied label IDs
+  - `attachments` — Array (omitted when empty); same shape as `gws gmail read`
 
 ---
 
@@ -580,7 +587,7 @@ Usage: gws gmail attachment [flags]
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
 | `--message-id` | string | | Yes | Message ID |
-| `--id` | string | | Yes | Attachment ID |
+| `--id` | string | | Yes | Attachment ID (from the `attachments` array on `gws gmail read` / `gws gmail thread`) |
 | `--output` | string | | Yes | Output file path |
 
 ### Output Fields (JSON)


### PR DESCRIPTION
Closes #181.

## Summary

`gws gmail attachment` requires `--id` (attachment ID), but no other
gmail command surfaced it — the only way to get one was the Gmail web
UI, which defeats the purpose of the CLI.

This PR adds an `attachments` array to `gws gmail read` and
`gws gmail thread` output. Each entry carries enough metadata to
download the attachment without leaving the terminal:

```json
{
  "id": "18abc123",
  "body": "...",
  "headers": {...},
  "labels": [...],
  "attachments": [
    {
      "filename": "resume.pdf",
      "mime_type": "application/pdf",
      "size": 12345,
      "attachment_id": "ANGjdJ9x...",
      "part_id": "1"
    }
  ]
}
```

## Changes

- `cmd/gmail.go`: new `extractAttachments` helper that walks the
  MessagePart tree and reports parts that carry both a filename and an
  AttachmentId. Wired into `runGmailRead` and `runGmailThread`. Field is
  omitted when no attachments are present (additive, backward-compatible).
- `cmd/gmail_test.go`: unit tests for flat payloads, nested multipart,
  no-attachment messages, and parts without an AttachmentId.
- `skills/gmail/SKILL.md` + `references/commands.md`: document the new
  field, the discovery path, and a jq one-liner end-to-end example.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./cmd/ -run "ExtractAttachments|GmailRead|GmailThread" -v` — pass
- [x] `go test ./...` — full module passes
- [x] `gofmt -w cmd/gmail.go cmd/gmail_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)