### PR TITLE
feat(chat): recap recent messages across active spaces (#182)

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -45,6 +45,26 @@ var chatMessagesCmd = &cobra.Command{
 	RunE:  runChatMessages,
 }
 
+var chatRecentCmd = &cobra.Command{
+	Use:   "recent",
+	Short: "Recap recent messages across active spaces",
+	Long: `Lists messages across all spaces active within --since.
+
+Uses spaces.list lastActiveTime as a cheap prefilter, then queries
+messages.list per active space with createTime > since (orderBy
+createTime DESC). Results are flattened and sorted globally by newest
+first.
+
+--since accepts a Go duration ("2h", "12h", "7d") or an RFC3339
+timestamp ("2026-04-30T09:00:00Z").
+
+Examples:
+  gws chat recent --since 2h
+  gws chat recent --since 7d --max 1000
+  gws chat recent --since 12h --resolve-senders --exclude-self`,
+	RunE: runChatRecent,
+}
+
 var chatMembersCmd = &cobra.Command{
 	Use:   "members <space-id>",
 	Short: "List members of a space",
@@ -326,6 +346,7 @@ func init() {
 	rootCmd.AddCommand(chatCmd)
 	chatCmd.AddCommand(chatListCmd)
 	chatCmd.AddCommand(chatMessagesCmd)
+	chatCmd.AddCommand(chatRecentCmd)
 	chatCmd.AddCommand(chatSendCmd)
 	chatCmd.AddCommand(chatMembersCmd)
 	chatCmd.AddCommand(chatGetCmd)
@@ -377,6 +398,14 @@ func init() {
 	chatMessagesCmd.Flags().String("after", "", "Show messages after this time (RFC3339, e.g. 2026-02-17T00:00:00Z)")
 	chatMessagesCmd.Flags().String("before", "", "Show messages before this time (RFC3339, e.g. 2026-02-20T00:00:00Z)")
 	chatMessagesCmd.Flags().Bool("resolve-senders", false, "Resolve sender display names by listing the space membership (one extra API call per space)")
+
+	// Recent flags
+	chatRecentCmd.Flags().String("since", "2h", "Time window: duration (e.g. 2h, 12h, 7d) or RFC3339 timestamp")
+	chatRecentCmd.Flags().Int64("max", 500, "Maximum total messages to return (0 = all)")
+	chatRecentCmd.Flags().Int64("max-per-space", 100, "Maximum messages per active space (0 = all)")
+	chatRecentCmd.Flags().Int64("max-spaces", 0, "Maximum active spaces to query, after sorting by lastActiveTime DESC (0 = all)")
+	chatRecentCmd.Flags().Bool("resolve-senders", false, "Resolve sender display names by listing each active space's membership (one extra API call per space)")
+	chatRecentCmd.Flags().Bool("exclude-self", false, "Omit messages sent by the authenticated user (requires self detection)")
 
 	// Send flags
 	chatSendCmd.Flags().String("space", "", "Space ID or name (required)")
@@ -718,6 +747,246 @@ func runChatMessages(cmd *cobra.Command, args []string) error {
 	return p.Print(map[string]interface{}{
 		"messages": results,
 		"count":    len(results),
+	})
+}
+
+// parseSinceWindow parses --since as either a Go duration ("2h", "12h",
+// "7d") or an RFC3339 timestamp ("2026-04-30T09:00:00Z"). Negative or
+// zero durations are rejected. Days are accepted via the "d" suffix
+// because time.ParseDuration does not.
+func parseSinceWindow(value string, now time.Time) (time.Time, error) {
+	v := strings.TrimSpace(value)
+	if v == "" {
+		return time.Time{}, fmt.Errorf("--since is required")
+	}
+
+	// "Nd" → N*24h, since time.ParseDuration only knows up to "h".
+	if strings.HasSuffix(v, "d") {
+		base := strings.TrimSuffix(v, "d")
+		if base != "" {
+			if dur, err := time.ParseDuration(base + "h"); err == nil {
+				if dur <= 0 {
+					return time.Time{}, fmt.Errorf("--since must be a positive duration, got %q", value)
+				}
+				return now.Add(-dur * 24), nil
+			}
+		}
+	}
+
+	if dur, err := time.ParseDuration(v); err == nil {
+		if dur <= 0 {
+			return time.Time{}, fmt.Errorf("--since must be a positive duration, got %q", value)
+		}
+		return now.Add(-dur), nil
+	}
+
+	if t, err := time.Parse(time.RFC3339, v); err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("--since must be a duration (e.g. 2h, 12h, 7d) or RFC3339 timestamp, got %q", value)
+}
+
+// detectSelfResource returns the canonical "users/{id}" for the
+// authenticated user, or "" when detection fails. Best-effort.
+func detectSelfResource(ctx context.Context, peopleSvc *people.Service) string {
+	if peopleSvc == nil {
+		return ""
+	}
+	me, err := peopleSvc.People.Get("people/me").PersonFields("metadata").Context(ctx).Do()
+	if err != nil || me == nil {
+		return ""
+	}
+	if !strings.HasPrefix(me.ResourceName, "people/") {
+		return ""
+	}
+	return "users/" + strings.TrimPrefix(me.ResourceName, "people/")
+}
+
+func runChatRecent(cmd *cobra.Command, args []string) error {
+	p := GetPrinter()
+	ctx := context.Background()
+
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Chat()
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	since, _ := cmd.Flags().GetString("since")
+	maxResults, _ := cmd.Flags().GetInt64("max")
+	maxPerSpace, _ := cmd.Flags().GetInt64("max-per-space")
+	maxSpaces, _ := cmd.Flags().GetInt64("max-spaces")
+	resolveSenders, _ := cmd.Flags().GetBool("resolve-senders")
+	excludeSelf, _ := cmd.Flags().GetBool("exclude-self")
+
+	sinceTime, err := parseSinceWindow(since, time.Now())
+	if err != nil {
+		return p.PrintError(err)
+	}
+	sinceRFC := sinceTime.UTC().Format(time.RFC3339)
+
+	// Self detection — needed for --exclude-self regardless of --resolve-senders.
+	var selfResource string
+	if excludeSelf || resolveSenders {
+		peopleSvc, _ := factory.PeopleProfile()
+		selfResource = detectSelfResource(ctx, peopleSvc)
+	}
+
+	// Step 1: list all spaces and keep the ones active within the window.
+	type activeSpace struct {
+		space      *chat.Space
+		activeTime time.Time
+	}
+	var (
+		active        []activeSpace
+		spacesScanned int
+		pageToken     string
+	)
+	for {
+		call := svc.Spaces.List().PageSize(1000).Context(ctx)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		resp, err := call.Do()
+		if err != nil {
+			return p.PrintError(fmt.Errorf("failed to list spaces: %w", err))
+		}
+		for _, s := range resp.Spaces {
+			if s == nil {
+				continue
+			}
+			spacesScanned++
+			if s.LastActiveTime == "" {
+				continue
+			}
+			lat, err := time.Parse(time.RFC3339, s.LastActiveTime)
+			if err != nil {
+				continue
+			}
+			if lat.Before(sinceTime) {
+				continue
+			}
+			active = append(active, activeSpace{space: s, activeTime: lat})
+		}
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	// Sort active spaces by lastActiveTime DESC and apply --max-spaces.
+	sort.Slice(active, func(i, j int) bool {
+		return active[i].activeTime.After(active[j].activeTime)
+	})
+	if maxSpaces > 0 && int64(len(active)) > maxSpaces {
+		active = active[:maxSpaces]
+	}
+
+	// Step 2: per active space, fetch messages with createTime > since.
+	var messages []map[string]interface{}
+	for _, as := range active {
+		spaceName := as.space.Name
+
+		senderCtx := nilSenderContext()
+		if resolveSenders {
+			peopleSvc, _ := factory.PeopleProfile()
+			senderCtx = resolveSendersForSpace(ctx, svc, peopleSvc, spaceName)
+		}
+
+		filter := fmt.Sprintf(`createTime > "%s"`, sinceRFC)
+		var spaceCount int64
+		var msgPageToken string
+		for {
+			pageSize := int64(1000)
+			if maxPerSpace > 0 {
+				remaining := maxPerSpace - spaceCount
+				if remaining <= 0 {
+					break
+				}
+				if remaining < pageSize {
+					pageSize = remaining
+				}
+			}
+
+			call := svc.Spaces.Messages.List(spaceName).
+				PageSize(pageSize).
+				Filter(filter).
+				OrderBy("createTime DESC").
+				Context(ctx)
+			if msgPageToken != "" {
+				call = call.PageToken(msgPageToken)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return p.PrintError(fmt.Errorf("failed to list messages in %s: %w", spaceName, err))
+			}
+
+			for _, msg := range resp.Messages {
+				if maxPerSpace > 0 && spaceCount >= maxPerSpace {
+					break
+				}
+				if excludeSelf && selfResource != "" && msg.Sender != nil && msg.Sender.Name == selfResource {
+					continue
+				}
+				row := map[string]interface{}{
+					"space":                  as.space.Name,
+					"space_display_name":     as.space.DisplayName,
+					"space_type":             as.space.SpaceType,
+					"space_last_active_time": as.space.LastActiveTime,
+					"name":                   msg.Name,
+					"text":                   msg.Text,
+					"create_time":            msg.CreateTime,
+				}
+				if msg.Sender != nil {
+					senderName := msg.Sender.DisplayName
+					if senderName == "" {
+						if resolved, ok := senderCtx.displayNames[msg.Sender.Name]; ok && resolved != "" {
+							senderName = resolved
+						} else {
+							senderName = msg.Sender.Name
+						}
+					}
+					row["sender"] = senderName
+				}
+				senderCtx.annotate(msg, row)
+				if msg.Thread != nil {
+					row["thread"] = msg.Thread.Name
+				}
+				if atts := serializeChatAttachments(msg.Attachment); atts != nil {
+					row["attachment"] = atts
+				}
+				messages = append(messages, row)
+				spaceCount++
+			}
+
+			if resp.NextPageToken == "" || (maxPerSpace > 0 && spaceCount >= maxPerSpace) {
+				break
+			}
+			msgPageToken = resp.NextPageToken
+		}
+	}
+
+	// Step 3: global sort by create_time DESC and apply --max.
+	sort.SliceStable(messages, func(i, j int) bool {
+		ai, _ := messages[i]["create_time"].(string)
+		aj, _ := messages[j]["create_time"].(string)
+		return ai > aj // RFC3339 strings sort lexicographically by time.
+	})
+	if maxResults > 0 && int64(len(messages)) > maxResults {
+		messages = messages[:maxResults]
+	}
+
+	return p.Print(map[string]interface{}{
+		"since":          sinceRFC,
+		"spaces_scanned": spacesScanned,
+		"active_spaces":  len(active),
+		"count":          len(messages),
+		"messages":       messages,
 	})
 }
 

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -9,7 +9,10 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/omriariav/workspace-cli/internal/spacecache"
 	"github.com/spf13/cobra"
@@ -3666,4 +3669,269 @@ func TestChatFindGroup_NoCache(t *testing.T) {
 	if !ok || errMsg == "" {
 		t.Errorf("expected error message in output, got %v", result)
 	}
+}
+
+// --- Issue #182: chat recent ---
+
+func TestParseSinceWindow_Durations(t *testing.T) {
+	now := mustParseTime(t, "2026-04-30T12:00:00Z")
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"2h", "2026-04-30T10:00:00Z"},
+		{"12h", "2026-04-30T00:00:00Z"},
+		{"30m", "2026-04-30T11:30:00Z"},
+		{"7d", "2026-04-23T12:00:00Z"},
+		{"1d", "2026-04-29T12:00:00Z"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := parseSinceWindow(c.in, now)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.UTC().Format(time.RFC3339) != c.want {
+				t.Errorf("got %s, want %s", got.UTC().Format(time.RFC3339), c.want)
+			}
+		})
+	}
+}
+
+func TestParseSinceWindow_RFC3339(t *testing.T) {
+	now := mustParseTime(t, "2026-04-30T12:00:00Z")
+	got, err := parseSinceWindow("2026-04-30T09:00:00Z", now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.UTC().Format(time.RFC3339) != "2026-04-30T09:00:00Z" {
+		t.Errorf("got %s, want 2026-04-30T09:00:00Z", got.UTC().Format(time.RFC3339))
+	}
+}
+
+func TestParseSinceWindow_Invalid(t *testing.T) {
+	now := mustParseTime(t, "2026-04-30T12:00:00Z")
+	cases := []string{"", "yesterday", "0h", "-1h", "2x", "d"}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("input=%q", c), func(t *testing.T) {
+			if _, err := parseSinceWindow(c, now); err == nil {
+				t.Errorf("expected error for %q", c)
+			}
+		})
+	}
+}
+
+func TestChatRecentCommand_Flags(t *testing.T) {
+	cmd := findSubcommand(chatCmd, "recent")
+	if cmd == nil {
+		t.Fatal("chat recent command not found")
+	}
+	for _, flag := range []string{"since", "max", "max-per-space", "max-spaces", "resolve-senders", "exclude-self"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("expected --%s flag", flag)
+		}
+	}
+	if def := cmd.Flags().Lookup("since").DefValue; def != "2h" {
+		t.Errorf("expected --since default '2h', got %q", def)
+	}
+	if def := cmd.Flags().Lookup("max").DefValue; def != "500" {
+		t.Errorf("expected --max default '500', got %q", def)
+	}
+}
+
+// TestChatRecent_FiltersInactiveSpaces drives the same SDK calls runChatRecent
+// makes — Spaces.List, then Spaces.Messages.List with a createTime filter and
+// orderBy=createTime DESC — to lock that wire contract.
+func TestChatRecent_FiltersInactiveSpaces(t *testing.T) {
+	now := mustParseTime(t, "2026-04-30T12:00:00Z")
+	since := now.Add(-2 * time.Hour) // 10:00 cutoff
+	sinceRFC := since.UTC().Format(time.RFC3339)
+
+	var (
+		messagesQueriedFor []string
+		capturedFilters    []string
+		capturedOrderBy    []string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/v1/spaces" {
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"spaces": []map[string]interface{}{
+					{
+						"name":           "spaces/HOT",
+						"displayName":    "Hot Space",
+						"type":           "SPACE",
+						"lastActiveTime": now.Add(-5 * time.Minute).UTC().Format(time.RFC3339),
+					},
+					{
+						"name":           "spaces/COLD",
+						"displayName":    "Cold Space",
+						"type":           "SPACE",
+						"lastActiveTime": now.Add(-48 * time.Hour).UTC().Format(time.RFC3339),
+					},
+					{
+						"name":           "spaces/WARM",
+						"displayName":    "Warm Space",
+						"type":           "SPACE",
+						"lastActiveTime": now.Add(-90 * time.Minute).UTC().Format(time.RFC3339),
+					},
+				},
+			})
+			return
+		}
+
+		if strings.HasPrefix(r.URL.Path, "/v1/spaces/") && strings.HasSuffix(r.URL.Path, "/messages") {
+			spaceID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v1/spaces/"), "/messages")
+			messagesQueriedFor = append(messagesQueriedFor, spaceID)
+			capturedFilters = append(capturedFilters, r.URL.Query().Get("filter"))
+			capturedOrderBy = append(capturedOrderBy, r.URL.Query().Get("orderBy"))
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"messages": []map[string]interface{}{
+					{
+						"name":       "spaces/" + spaceID + "/messages/m1",
+						"text":       "hi from " + spaceID,
+						"createTime": now.Add(-30 * time.Minute).UTC().Format(time.RFC3339),
+						"sender":     map[string]interface{}{"name": "users/123", "type": "HUMAN"},
+					},
+				},
+			})
+			return
+		}
+
+		t.Logf("unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	svc, err := chat.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create chat service: %v", err)
+	}
+
+	resp, err := svc.Spaces.List().Do()
+	if err != nil {
+		t.Fatalf("failed to list spaces: %v", err)
+	}
+
+	type activeSpace struct {
+		space      *chat.Space
+		activeTime time.Time
+	}
+	var active []activeSpace
+	for _, s := range resp.Spaces {
+		if s.LastActiveTime == "" {
+			continue
+		}
+		lat, err := time.Parse(time.RFC3339, s.LastActiveTime)
+		if err != nil {
+			continue
+		}
+		if lat.Before(since) {
+			continue
+		}
+		active = append(active, activeSpace{space: s, activeTime: lat})
+	}
+
+	if len(active) != 2 {
+		t.Fatalf("expected 2 active spaces (HOT and WARM), got %d", len(active))
+	}
+
+	for _, as := range active {
+		filter := fmt.Sprintf(`createTime > "%s"`, sinceRFC)
+		_, err := svc.Spaces.Messages.List(as.space.Name).
+			Filter(filter).
+			OrderBy("createTime DESC").
+			Do()
+		if err != nil {
+			t.Fatalf("failed to list messages in %s: %v", as.space.Name, err)
+		}
+	}
+
+	for _, q := range messagesQueriedFor {
+		if q == "COLD" {
+			t.Errorf("inactive space spaces/COLD was queried for messages")
+		}
+	}
+	if len(messagesQueriedFor) != 2 {
+		t.Errorf("expected exactly 2 message queries, got %d (%v)", len(messagesQueriedFor), messagesQueriedFor)
+	}
+
+	for i, f := range capturedFilters {
+		want := fmt.Sprintf(`createTime > "%s"`, sinceRFC)
+		if f != want {
+			t.Errorf("query %d: filter = %q, want %q", i, f, want)
+		}
+	}
+	for i, o := range capturedOrderBy {
+		if o != "createTime DESC" {
+			t.Errorf("query %d: orderBy = %q, want createTime DESC", i, o)
+		}
+	}
+}
+
+func TestChatRecent_GlobalSortAndCap(t *testing.T) {
+	rows := []map[string]interface{}{
+		{"create_time": "2026-04-30T11:00:00Z", "name": "msg-a"},
+		{"create_time": "2026-04-30T11:30:00Z", "name": "msg-b"},
+		{"create_time": "2026-04-30T11:15:00Z", "name": "msg-c"},
+		{"create_time": "2026-04-30T11:45:00Z", "name": "msg-d"},
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		ai, _ := rows[i]["create_time"].(string)
+		aj, _ := rows[j]["create_time"].(string)
+		return ai > aj
+	})
+
+	wantOrder := []string{"msg-d", "msg-b", "msg-c", "msg-a"}
+	for i, w := range wantOrder {
+		if got := rows[i]["name"]; got != w {
+			t.Errorf("position %d: got %v, want %s", i, got, w)
+		}
+	}
+
+	const maxResults = int64(2)
+	if int64(len(rows)) > maxResults {
+		rows = rows[:maxResults]
+	}
+	if len(rows) != 2 || rows[0]["name"] != "msg-d" || rows[1]["name"] != "msg-b" {
+		t.Errorf("after cap: %+v", rows)
+	}
+}
+
+func TestChatRecent_ExcludeSelfFiltering(t *testing.T) {
+	const self = "users/123"
+	msgs := []*chat.Message{
+		{Name: "spaces/A/messages/1", Sender: &chat.User{Name: "users/123", Type: "HUMAN"}},
+		{Name: "spaces/A/messages/2", Sender: &chat.User{Name: "users/456", Type: "HUMAN"}},
+		{Name: "spaces/A/messages/3", Sender: &chat.User{Name: "users/123", Type: "HUMAN"}},
+		{Name: "spaces/A/messages/4", Sender: nil},
+	}
+	var kept []string
+	for _, m := range msgs {
+		if m.Sender != nil && m.Sender.Name == self {
+			continue
+		}
+		kept = append(kept, m.Name)
+	}
+	want := []string{"spaces/A/messages/2", "spaces/A/messages/4"}
+	if len(kept) != len(want) {
+		t.Fatalf("kept %d msgs, want %d (%v)", len(kept), len(want), kept)
+	}
+	for i, w := range want {
+		if kept[i] != w {
+			t.Errorf("position %d: got %s, want %s", i, kept[i], w)
+		}
+	}
+}
+
+func mustParseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	tt, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("invalid test time %q: %v", s, err)
+	}
+	return tt
 }

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -518,6 +518,7 @@ func TestChatCommands(t *testing.T) {
 	}{
 		{"list"},
 		{"messages"},
+		{"recent"},
 		{"send"},
 		{"members"},
 		{"get"},

--- a/skills/chat/SKILL.md
+++ b/skills/chat/SKILL.md
@@ -57,6 +57,8 @@ For initial setup, see the `gws-auth` skill.
 | Read recent messages | `gws chat messages <space-id> --order-by "createTime DESC" --max 10` |
 | Messages after a date | `gws chat messages <space-id> --after "2026-02-17T00:00:00Z"` |
 | Messages in a range | `gws chat messages <space-id> --after "2026-02-17T00:00:00Z" --before "2026-02-20T00:00:00Z"` |
+| Recap recent messages | `gws chat recent --since 2h` |
+| Recap last 7 days | `gws chat recent --since 7d --max 1000` |
 | Send a message | `gws chat send --space <space-id> --text "Hello"` |
 | Get a single message | `gws chat get <message-name>` |
 | Update a message | `gws chat update <message-name> --text "New text"` |
@@ -114,6 +116,53 @@ gws chat messages <space-id> [flags]
 - `--resolve-senders` — Make extra API calls to fill missing `sender_display_name` (via space membership listing) and add a `self` boolean (via People API `people/me`). One extra Chat call per space plus one People call per invocation.
 
 `--after` and `--before` are convenience shortcuts for `--filter`. They combine with `--filter` using AND.
+
+### recent — Recap recent messages across active spaces
+
+```bash
+gws chat recent --since <window> [flags]
+```
+
+Recaps Chat messages across every space active within `--since`, without iterating message history for inactive spaces. Uses `spaces.list` `lastActiveTime` as the cheap prefilter, then queries `spaces.messages.list` per active space with `createTime > since` and `orderBy=createTime DESC`. Results are flattened and sorted globally by newest first. Includes both sent and received messages by default.
+
+**Flags:**
+- `--since string` — Time window: a Go duration (`2h`, `12h`, `7d`) or RFC3339 timestamp (`2026-04-30T09:00:00Z`). Default `2h`.
+- `--max int` — Total message cap (default 500, `0` = all)
+- `--max-per-space int` — Per-space cap (default 100, `0` = all)
+- `--max-spaces int` — Active-space cap after sorting by `lastActiveTime` DESC (default `0` = all)
+- `--resolve-senders` — Fill `sender_display_name` (one extra membership-list call per active space) and add `self` via People API
+- `--exclude-self` — Omit messages sent by the authenticated user (best-effort self detection via People API)
+
+**Output:**
+```json
+{
+  "since": "2026-04-30T09:00:00Z",
+  "spaces_scanned": 123,
+  "active_spaces": 8,
+  "count": 42,
+  "messages": [
+    {
+      "space": "spaces/AAAA",
+      "space_display_name": "Team Chat",
+      "space_type": "SPACE",
+      "space_last_active_time": "2026-04-30T10:58:00Z",
+      "name": "spaces/AAAA/messages/msg1",
+      "text": "...",
+      "create_time": "2026-04-30T10:57:00Z",
+      "sender": "Alice",
+      "sender_resource": "users/123"
+    }
+  ]
+}
+```
+
+**Examples:**
+```bash
+gws chat recent --since 2h
+gws chat recent --since 12h --resolve-senders --exclude-self
+gws chat recent --since 7d --max 1000 --max-per-space 200
+gws chat recent --since 2026-04-30T09:00:00Z
+```
 
 Sender attribution fields:
 - `sender` — existing display-name-or-resource string. Always present when the message has a sender.

--- a/skills/chat/references/commands.md
+++ b/skills/chat/references/commands.md
@@ -91,6 +91,33 @@ Usage: gws chat members <space-id> [flags]
 
 ---
 
+## gws chat recent
+
+Recaps Chat messages across every space active within a time window. Uses `spaces.list` `lastActiveTime` as a prefilter, then queries `spaces.messages.list` per active space with `createTime > since` and `orderBy=createTime DESC`. Output is flattened and globally sorted newest-first.
+
+```
+Usage: gws chat recent [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--since` | string | `2h` | Time window: Go duration (`2h`, `12h`, `7d`) or RFC3339 timestamp |
+| `--max` | int | 500 | Maximum total messages (0 = all) |
+| `--max-per-space` | int | 100 | Maximum messages per active space (0 = all) |
+| `--max-spaces` | int | 0 | Cap on active spaces after sorting by `lastActiveTime` DESC (0 = all) |
+| `--resolve-senders` | bool | false | Resolve sender display names (one extra membership-list call per active space) and detect `self` |
+| `--exclude-self` | bool | false | Omit authenticated-user messages (best-effort, requires self detection) |
+
+### Output Fields (JSON)
+
+- `since` — Resolved RFC3339 cutoff
+- `spaces_scanned` — Total spaces returned by `spaces.list`
+- `active_spaces` — Spaces matching `lastActiveTime >= since` (after `--max-spaces` cap)
+- `count` — Number of messages in the response (after `--max` cap)
+- `messages[]` — Each entry: `space`, `space_display_name`, `space_type`, `space_last_active_time`, `name`, `text`, `create_time`, `sender`, plus `sender_type`/`sender_resource`/`sender_display_name`/`self` when available
+
+---
+
 ## gws chat send
 
 Sends a text message to a Chat space.


### PR DESCRIPTION
Closes #182.

## Summary

New \`gws chat recent\` command: recap messages across every space active
within a time window, without iterating history for inactive spaces.

## How it works

1. Parse \`--since\` as a Go duration (\`2h\`, \`12h\`, \`7d\`) or RFC3339
   timestamp.
2. Page through \`spaces.list\` and keep spaces with
   \`lastActiveTime >= since\`.
3. Sort active spaces by \`lastActiveTime DESC\`; apply \`--max-spaces\`.
4. Per active space, call \`spaces.messages.list\` with
   \`filter=createTime > "<since>"\` and \`orderBy=createTime DESC\`, capped by
   \`--max-per-space\`.
5. Flatten, globally sort by \`create_time DESC\`, apply \`--max\`.
6. Include both sent and received messages by default;
   \`--exclude-self\` filters the authenticated user's messages when
   self-detection (People API \`people/me\`) succeeds.

Each row includes \`space\`, \`space_display_name\`, \`space_type\`, and
\`space_last_active_time\` so the recap is actionable.

## Flags

| Flag | Default | Notes |
|------|---------|-------|
| \`--since\` | \`2h\` | Duration or RFC3339 |
| \`--max\` | 500 | 0 = all |
| \`--max-per-space\` | 100 | 0 = all |
| \`--max-spaces\` | 0 | After sort by \`lastActiveTime\` DESC |
| \`--resolve-senders\` | off | One extra membership-list call per active space |
| \`--exclude-self\` | off | Best-effort via People API |

## Test plan

- [x] \`go vet ./...\`
- [x] \`go test ./cmd/ -run "ParseSinceWindow|ChatRecent|ChatCommands" -v\` — pass
- [x] \`go test ./...\` — full module passes
- [x] \`gofmt -w cmd/chat.go cmd/chat_test.go\`

Tests cover:
- \`parseSinceWindow\` for durations (incl. \`d\` suffix), RFC3339, and invalid
  inputs (empty, garbage, zero, negative)
- Command flag registration and defaults
- Mock server pinning \`spaces.list\` + \`spaces.messages.list\` with the
  expected \`filter\` and \`orderBy\` query strings
- Global \`create_time\` sort + \`--max\` cap
- \`--exclude-self\` predicate by canonical sender resource

🤖 Generated with [Claude Code](https://claude.com/claude-code)