### PR TITLE
release: v1.40.0 — exit codes + people scope fix (#190, #191)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.40.0** - Non-zero exit codes for API errors: 1=generic, 2=CLI usage, 3=auth (401/403), 4=transient (429/5xx). API/runtime errors go to stderr as structured JSON; CLI usage errors (wrong args, unknown flags) go to stderr as plain text. Stdout is reserved for successful responses. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
+**v1.40.0** - Non-zero exit codes for API errors: 1=generic API/runtime, 2=CLI usage, 3=auth (401/403), 4=transient (429/5xx). CLI usage errors — both Cobra-level (wrong args, unknown flags) and runtime input-validation (missing `--params resourceName`, mutually-exclusive flags, out-of-range values) — exit 2 with plain text on stderr. API/runtime errors exit 1/3/4 with structured JSON on stderr. Stdout is reserved for successful responses. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
 
 ## Roadmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.40.0** - Non-zero exit codes for API errors: 1=generic, 2=CLI usage, 3=auth (401/403), 4=transient (429/5xx). Errors now go to stderr as structured JSON; stdout is reserved for successful responses. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
+**v1.40.0** - Non-zero exit codes for API errors: 1=generic, 2=CLI usage, 3=auth (401/403), 4=transient (429/5xx). API/runtime errors go to stderr as structured JSON; CLI usage errors (wrong args, unknown flags) go to stderr as plain text. Stdout is reserved for successful responses. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
 
 ## Roadmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.40.0** - Non-zero exit codes for API errors: 1=generic API/runtime, 2=CLI usage, 3=auth (401/403), 4=transient (429/5xx). CLI usage errors — both Cobra-level (wrong args, unknown flags) and runtime input-validation (missing `--params resourceName`, mutually-exclusive flags, out-of-range values) — exit 2 with plain text on stderr. API/runtime errors exit 1/3/4 with a structured error on stderr; the format follows `--format` (JSON by default, `yaml` or `text` if set). Stdout is reserved for successful responses. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
+**v1.40.0** - Non-zero exit codes: 0=success, 1=generic API/runtime, 2=CLI usage / runtime input-validation, 3=auth (401/403), 4=transient (429/5xx). CLI usage errors (Cobra-level: wrong args, unknown flags) and runtime input-validation (required-flag checks, mutually-exclusive flags, out-of-range/enum values, malformed `--params`) exit 2 with plain text on stderr. Server/file state errors (no cache found, document empty, resource not found, "not an attendee") and wrapped API errors exit 1/3/4 with a structured error on stderr; the format follows `--format` (JSON by default, `yaml` or `text` if set). Stdout is reserved for successful responses. See `cmd/usage.go` for the convention new commands should follow. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
 
 ## Roadmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.40.0** - Non-zero exit codes for API errors: 1=generic API/runtime, 2=CLI usage, 3=auth (401/403), 4=transient (429/5xx). CLI usage errors — both Cobra-level (wrong args, unknown flags) and runtime input-validation (missing `--params resourceName`, mutually-exclusive flags, out-of-range values) — exit 2 with plain text on stderr. API/runtime errors exit 1/3/4 with structured JSON on stderr. Stdout is reserved for successful responses. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
+**v1.40.0** - Non-zero exit codes for API errors: 1=generic API/runtime, 2=CLI usage, 3=auth (401/403), 4=transient (429/5xx). CLI usage errors — both Cobra-level (wrong args, unknown flags) and runtime input-validation (missing `--params resourceName`, mutually-exclusive flags, out-of-range values) — exit 2 with plain text on stderr. API/runtime errors exit 1/3/4 with a structured error on stderr; the format follows `--format` (JSON by default, `yaml` or `text` if set). Stdout is reserved for successful responses. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
 
 ## Roadmap
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.39.0** - Adds `--raw` and `--params` to six list/get commands for programmatic, API-shape JSON output (skips field renaming, base64 decoding, header collapsing). New noun-verb command paths: `gws chat spaces list`, `gws chat messages list`, `gws chat members list`, and `gws people get`. `gmail list` switches to `users.messages.list` shape under `--raw`. `--all` aggregates the top-level list field across pages and drops `nextPageToken`. `--params` is a JSON object whose keys map directly to Google API request parameters and override the equivalent CLI flags (params win). `contacts get` and `gmail thread` relaxed to accept the resource id via `--params resourceName`/`--params id`.
+**v1.40.0** - Non-zero exit codes for API errors: 1=generic, 2=CLI usage, 3=auth (401/403), 4=transient (429/5xx). Errors now go to stderr as structured JSON; stdout is reserved for successful responses. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
 
 ## Roadmap
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.39.0
+VERSION ?= 1.40.0
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -66,7 +66,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	clientSecret := config.GetClientSecret()
 
 	if clientID == "" || clientSecret == "" {
-		return p.PrintError(fmt.Errorf("missing credentials: set GWS_CLIENT_ID and GWS_CLIENT_SECRET environment variables, or use --client-id and --client-secret flags"))
+		return usageErrorf("missing credentials: set GWS_CLIENT_ID and GWS_CLIENT_SECRET environment variables, or use --client-id and --client-secret flags")
 	}
 
 	// Determine scopes and services based on --services flag, config, or all

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -74,9 +74,9 @@ func runLogin(cmd *cobra.Command, args []string) error {
 
 	// Validate service names — fail fast on unknown services
 	if unknown := auth.ValidateServices(grantedServices); len(unknown) > 0 {
-		return p.PrintError(fmt.Errorf("unknown service(s): %s\nValid services: %s",
+		return usageErrorf("unknown service(s): %s\nValid services: %s",
 			strings.Join(unknown, ", "),
-			strings.Join(auth.ValidServiceNames(), ", ")))
+			strings.Join(auth.ValidServiceNames(), ", "))
 	}
 
 	client := auth.NewOAuthClient(clientID, clientSecret, scopes)

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -555,7 +555,7 @@ func runCalendarEvents(cmd *cobra.Command, args []string) error {
 		} else if t, err := time.ParseInLocation("2006-01-02", fromStr, time.Local); err == nil {
 			start = t
 		} else {
-			return p.PrintError(fmt.Errorf("invalid --from date %q: use YYYY-MM-DD or RFC3339 format", fromStr))
+			return usageErrorf("invalid --from date %q: use YYYY-MM-DD or RFC3339 format", fromStr)
 		}
 	}
 	timeMin := start.Format(time.RFC3339)
@@ -579,7 +579,7 @@ func runCalendarEvents(cmd *cobra.Command, args []string) error {
 	}
 	if updatedMin != "" {
 		if _, err := time.Parse(time.RFC3339, updatedMin); err != nil {
-			return p.PrintError(fmt.Errorf("invalid --updated-min %q: use RFC3339 format", updatedMin))
+			return usageErrorf("invalid --updated-min %q: use RFC3339 format", updatedMin)
 		}
 		call = call.UpdatedMin(updatedMin)
 	}
@@ -886,7 +886,7 @@ func runCalendarRsvp(cmd *cobra.Command, args []string) error {
 	message, _ := cmd.Flags().GetString("message")
 
 	if !validRsvpResponses[response] {
-		return p.PrintError(fmt.Errorf("invalid response '%s': must be accepted, declined, or tentative", response))
+		return usageErrorf("invalid response '%s': must be accepted, declined, or tentative", response)
 	}
 
 	// Get the event to find our attendee entry
@@ -1508,7 +1508,7 @@ func runCalendarShare(cmd *cobra.Command, args []string) error {
 	role, _ := cmd.Flags().GetString("role")
 
 	if !validAclRoles[role] {
-		return p.PrintError(fmt.Errorf("invalid role '%s': must be reader, writer, owner, or freeBusyReader", role))
+		return usageErrorf("invalid role '%s': must be reader, writer, owner, or freeBusyReader", role)
 	}
 
 	factory, err := client.NewFactory(ctx)
@@ -1579,7 +1579,7 @@ func runCalendarUpdateAcl(cmd *cobra.Command, args []string) error {
 	role, _ := cmd.Flags().GetString("role")
 
 	if !validAclRoles[role] {
-		return p.PrintError(fmt.Errorf("invalid role '%s': must be reader, writer, owner, or freeBusyReader", role))
+		return usageErrorf("invalid role '%s': must be reader, writer, owner, or freeBusyReader", role)
 	}
 
 	factory, err := client.NewFactory(ctx)

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -732,7 +732,7 @@ func runCalendarUpdate(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if !hasChanges {
-		return p.PrintError(fmt.Errorf("at least one update flag is required (--title, --start, --end, --description, --location, --add-attendees)"))
+		return usageErrorf("at least one update flag is required (--title, --start, --end, --description, --location, --add-attendees)")
 	}
 
 	factory, err := client.NewFactory(ctx)

--- a/cmd/calendar.go
+++ b/cmd/calendar.go
@@ -525,17 +525,6 @@ func runCalendarList(cmd *cobra.Command, args []string) error {
 
 func runCalendarEvents(cmd *cobra.Command, args []string) error {
 	p := GetPrinter()
-	ctx := context.Background()
-
-	factory, err := client.NewFactory(ctx)
-	if err != nil {
-		return p.PrintError(err)
-	}
-
-	svc, err := factory.Calendar()
-	if err != nil {
-		return p.PrintError(err)
-	}
 
 	days, _ := cmd.Flags().GetInt("days")
 	fromStr, _ := cmd.Flags().GetString("from")
@@ -548,6 +537,8 @@ func runCalendarEvents(cmd *cobra.Command, args []string) error {
 	timezone, _ := cmd.Flags().GetString("timezone")
 	updatedMin, _ := cmd.Flags().GetString("updated-min")
 
+	// Pure input validation before auth — invalid CLI input must surface
+	// as ExitUsage, not as an auth failure.
 	start := time.Now()
 	if fromStr != "" {
 		if t, err := time.Parse(time.RFC3339, fromStr); err == nil {
@@ -558,6 +549,23 @@ func runCalendarEvents(cmd *cobra.Command, args []string) error {
 			return usageErrorf("invalid --from date %q: use YYYY-MM-DD or RFC3339 format", fromStr)
 		}
 	}
+	if updatedMin != "" {
+		if _, err := time.Parse(time.RFC3339, updatedMin); err != nil {
+			return usageErrorf("invalid --updated-min %q: use RFC3339 format", updatedMin)
+		}
+	}
+
+	ctx := context.Background()
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Calendar()
+	if err != nil {
+		return p.PrintError(err)
+	}
+
 	timeMin := start.Format(time.RFC3339)
 	timeMax := start.AddDate(0, 0, days).Format(time.RFC3339)
 
@@ -578,9 +586,7 @@ func runCalendarEvents(cmd *cobra.Command, args []string) error {
 		call = call.TimeZone(timezone)
 	}
 	if updatedMin != "" {
-		if _, err := time.Parse(time.RFC3339, updatedMin); err != nil {
-			return usageErrorf("invalid --updated-min %q: use RFC3339 format", updatedMin)
-		}
+		// Already validated above.
 		call = call.UpdatedMin(updatedMin)
 	}
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -646,7 +646,7 @@ func runChatMessages(cmd *cobra.Command, args []string) error {
 		spaceName = ensureSpaceName(args[0])
 	}
 	if params, perr := parseParams(cmd); perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	} else if v, ok := paramString(params, "parent"); ok && v != "" {
 		spaceName = v
 	}
@@ -1060,7 +1060,7 @@ func runChatMembers(cmd *cobra.Command, args []string) error {
 		spaceName = ensureSpaceName(args[0])
 	}
 	if params, perr := parseParams(cmd); perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	} else if v, ok := paramString(params, "parent"); ok && v != "" {
 		spaceName = v
 	}

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -1650,7 +1650,7 @@ func runChatUpdateSpace(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(masks) == 0 {
-		return p.PrintError(fmt.Errorf("at least one of --display-name or --description is required"))
+		return usageErrorf("at least one of --display-name or --description is required")
 	}
 
 	updated, err := svc.Spaces.Patch(spaceName, space).UpdateMask(strings.Join(masks, ",")).Context(ctx).Do()
@@ -1736,10 +1736,10 @@ func runChatFindDm(cmd *cobra.Command, args []string) error {
 	email, _ := cmd.Flags().GetString("email")
 
 	if user == "" && email == "" {
-		return p.PrintError(fmt.Errorf("provide either --user or --email"))
+		return usageErrorf("provide either --user or --email")
 	}
 	if user != "" && email != "" {
-		return p.PrintError(fmt.Errorf("--user and --email are mutually exclusive"))
+		return usageErrorf("--user and --email are mutually exclusive")
 	}
 	if email != "" {
 		user = "users/" + email
@@ -2468,7 +2468,7 @@ func runChatFindGroup(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if len(emails) == 0 {
-		return p.PrintError(fmt.Errorf("--members must contain at least one email address"))
+		return usageErrorf("--members must contain at least one email address")
 	}
 
 	matches := spacecache.FindByMembers(cache, emails)
@@ -2511,7 +2511,7 @@ func runChatFindSpace(cmd *cobra.Command, args []string) error {
 
 	name := strings.TrimSpace(rawName)
 	if name == "" {
-		return p.PrintError(fmt.Errorf("--name must not be empty"))
+		return usageErrorf("--name must not be empty")
 	}
 
 	if spaceType != "" {

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -1775,18 +1775,18 @@ func runChatSetupSpace(cmd *cobra.Command, args []string) error {
 	switch spaceType {
 	case "SPACE", "DIRECT_MESSAGE", "GROUP_CHAT":
 	default:
-		return p.PrintError(fmt.Errorf("invalid --type %q: must be SPACE, GROUP_CHAT, or DIRECT_MESSAGE", spaceType))
+		return usageErrorf("invalid --type %q: must be SPACE, GROUP_CHAT, or DIRECT_MESSAGE", spaceType)
 	}
 
 	// Validate flags based on space type
 	switch spaceType {
 	case "DIRECT_MESSAGE", "GROUP_CHAT":
 		if membersStr == "" {
-			return p.PrintError(fmt.Errorf("--members is required for %s type", spaceType))
+			return usageErrorf("--members is required for %s type", spaceType)
 		}
 	default: // SPACE
 		if displayName == "" {
-			return p.PrintError(fmt.Errorf("--display-name is required for %s type", spaceType))
+			return usageErrorf("--display-name is required for %s type", spaceType)
 		}
 	}
 
@@ -2389,7 +2389,7 @@ func runChatBuildCache(cmd *cobra.Command, args []string) error {
 	switch spaceType {
 	case "GROUP_CHAT", "SPACE", "DIRECT_MESSAGE", "all":
 	default:
-		return p.PrintError(fmt.Errorf("invalid --type %q: must be GROUP_CHAT, SPACE, DIRECT_MESSAGE, or all", spaceType))
+		return usageErrorf("invalid --type %q: must be GROUP_CHAT, SPACE, DIRECT_MESSAGE, or all", spaceType)
 	}
 
 	start := time.Now()
@@ -2518,7 +2518,7 @@ func runChatFindSpace(cmd *cobra.Command, args []string) error {
 		switch strings.ToUpper(spaceType) {
 		case "SPACE", "GROUP_CHAT", "DIRECT_MESSAGE":
 		default:
-			return p.PrintError(fmt.Errorf("invalid --type %q: must be SPACE, GROUP_CHAT, or DIRECT_MESSAGE", spaceType))
+			return usageErrorf("invalid --type %q: must be SPACE, GROUP_CHAT, or DIRECT_MESSAGE", spaceType)
 		}
 	}
 

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -651,7 +651,7 @@ func runChatMessages(cmd *cobra.Command, args []string) error {
 		spaceName = v
 	}
 	if spaceName == "" {
-		return p.PrintError(errors.New("chat messages: a space id is required (positional arg or --params parent)"))
+		return usageErrorf("chat messages: a space id is required (positional arg or --params parent)")
 	}
 
 	ctx := context.Background()
@@ -1065,7 +1065,7 @@ func runChatMembers(cmd *cobra.Command, args []string) error {
 		spaceName = v
 	}
 	if spaceName == "" {
-		return p.PrintError(errors.New("chat members: a space id is required (positional arg or --params parent)"))
+		return usageErrorf("chat members: a space id is required (positional arg or --params parent)")
 	}
 
 	ctx := context.Background()

--- a/cmd/chat_raw.go
+++ b/cmd/chat_raw.go
@@ -108,7 +108,7 @@ func runChatListRaw(cmd *cobra.Command, svc *chat.Service, filter string, pageSi
 	p := GetPrinter()
 	params, perr := parseParams(cmd)
 	if perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	}
 
 	if v, ok := paramString(params, "filter"); ok {
@@ -196,7 +196,7 @@ func runChatMessagesRaw(cmd *cobra.Command, svc *chat.Service, spaceName string,
 	p := GetPrinter()
 	params, perr := parseParams(cmd)
 	if perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	}
 
 	if v, ok := paramString(params, "parent"); ok && v != "" {
@@ -303,7 +303,7 @@ func runChatMembersRaw(cmd *cobra.Command, svc *chat.Service, spaceName string, 
 	p := GetPrinter()
 	params, perr := parseParams(cmd)
 	if perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	}
 
 	if v, ok := paramString(params, "parent"); ok && v != "" {

--- a/cmd/chat_raw.go
+++ b/cmd/chat_raw.go
@@ -10,7 +10,6 @@ package cmd
 // is concatenated across pages and nextPageToken is dropped.
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -204,7 +203,7 @@ func runChatMessagesRaw(cmd *cobra.Command, svc *chat.Service, spaceName string,
 		spaceName = v
 	}
 	if spaceName == "" {
-		return p.PrintError(errors.New("chat messages list: a space name is required (positional arg or --params parent)"))
+		return usageErrorf("chat messages list: a space name is required (positional arg or --params parent)")
 	}
 	pageSize := int64(0)
 	if v, ok := paramInt64(params, "pageSize"); ok {
@@ -311,7 +310,7 @@ func runChatMembersRaw(cmd *cobra.Command, svc *chat.Service, spaceName string, 
 		spaceName = v
 	}
 	if spaceName == "" {
-		return p.PrintError(errors.New("chat members list: a space name is required (positional arg or --params parent)"))
+		return usageErrorf("chat members list: a space name is required (positional arg or --params parent)")
 	}
 	pageSize := int64(0)
 	if v, ok := paramInt64(params, "pageSize"); ok {

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -3275,15 +3275,15 @@ func TestChatFindGroup_ErrorOnEmptyMembers(t *testing.T) {
 	cmd := newFindGroupCmd()
 	cmd.Flags().Set("members", "  ,  , ")
 
-	// Capture stdout (PrintError writes error JSON to stdout)
-	oldStdout := os.Stdout
+	// Capture stderr (PrintError writes error JSON to stderr per #190)
+	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
-	os.Stdout = w
+	os.Stderr = w
 
 	cmd.RunE(cmd, []string{})
 
 	w.Close()
-	os.Stdout = oldStdout
+	os.Stderr = oldStderr
 
 	output, _ := io.ReadAll(r)
 	var result map[string]interface{}
@@ -3498,12 +3498,12 @@ func TestChatFindSpace_InvalidType(t *testing.T) {
 	cmd.Flags().Set("name", "sales")
 	cmd.Flags().Set("type", "BOGUS")
 
-	oldStdout := os.Stdout
+	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
-	os.Stdout = w
+	os.Stderr = w
 	cmd.RunE(cmd, []string{})
 	w.Close()
-	os.Stdout = oldStdout
+	os.Stderr = oldStderr
 
 	output, _ := io.ReadAll(r)
 	var result map[string]interface{}
@@ -3639,12 +3639,12 @@ func TestChatFindSpace_NoCache(t *testing.T) {
 	cmd := newFindSpaceCmd()
 	cmd.Flags().Set("name", "sales")
 
-	oldStdout := os.Stdout
+	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
-	os.Stdout = w
+	os.Stderr = w
 	cmd.RunE(cmd, []string{})
 	w.Close()
-	os.Stdout = oldStdout
+	os.Stderr = oldStderr
 
 	output, _ := io.ReadAll(r)
 	var result map[string]interface{}
@@ -3666,14 +3666,14 @@ func TestChatFindGroup_NoCache(t *testing.T) {
 	cmd := newFindGroupCmd()
 	cmd.Flags().Set("members", "alice@example.com")
 
-	oldStdout := os.Stdout
+	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
-	os.Stdout = w
+	os.Stderr = w
 
 	cmd.RunE(cmd, []string{})
 
 	w.Close()
-	os.Stdout = oldStdout
+	os.Stderr = oldStderr
 
 	output, _ := io.ReadAll(r)
 	var result map[string]interface{}

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -3286,13 +3286,9 @@ func TestChatFindGroup_ErrorOnEmptyMembers(t *testing.T) {
 	os.Stderr = oldStderr
 
 	output, _ := io.ReadAll(r)
-	var result map[string]interface{}
-	if err := json.Unmarshal(output, &result); err != nil {
-		t.Fatalf("failed to parse output: %v\nraw: %s", err, output)
-	}
-	errMsg, ok := result["error"].(string)
-	if !ok || errMsg == "" {
-		t.Errorf("expected error message in output, got %v", result)
+	// usageErrorf produces plain "Error: ..." now (was JSON before).
+	if !strings.Contains(string(output), "--members must contain at least one email address") {
+		t.Errorf("expected --members validation error, got %s", output)
 	}
 }
 

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -3502,12 +3502,9 @@ func TestChatFindSpace_InvalidType(t *testing.T) {
 	os.Stderr = oldStderr
 
 	output, _ := io.ReadAll(r)
-	var result map[string]interface{}
-	if err := json.Unmarshal(output, &result); err != nil {
-		t.Fatalf("failed to parse output: %v\nraw: %s", err, output)
-	}
-	if msg, _ := result["error"].(string); msg == "" {
-		t.Errorf("expected error in output, got %v", result)
+	// usageErrorf produces plain "Error: ..." (was JSON before #192).
+	if !strings.Contains(string(output), "invalid --type") {
+		t.Errorf("expected --type validation error, got %s", output)
 	}
 }
 

--- a/cmd/contacts.go
+++ b/cmd/contacts.go
@@ -635,7 +635,7 @@ func runContactsBatchUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if fileData.UpdateMask == "" {
-		return p.PrintError(fmt.Errorf("update_mask is required in the JSON file"))
+		return usageErrorf("update_mask is required in the JSON file")
 	}
 
 	req := &people.BatchUpdateContactsRequest{

--- a/cmd/contacts.go
+++ b/cmd/contacts.go
@@ -310,7 +310,7 @@ func runContactsGet(cmd *cobra.Command, args []string) error {
 		pf = v
 	}
 	if resourceName == "" {
-		return p.PrintError(fmt.Errorf("contacts get: resource-name is required (positional arg or --params resourceName)"))
+		return usageErrorf("contacts get: resource-name is required (positional arg or --params resourceName)")
 	}
 
 	ctx := context.Background()
@@ -433,7 +433,7 @@ func runContactsUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(updateFields) == 0 {
-		return p.PrintError(fmt.Errorf("at least one field to update must be specified (--name, --email, --phone, --organization, --title)"))
+		return usageErrorf("at least one field to update must be specified (--name, --email, --phone, --organization, --title)")
 	}
 
 	ctx := context.Background()

--- a/cmd/contacts.go
+++ b/cmd/contacts.go
@@ -301,7 +301,7 @@ func runContactsGet(cmd *cobra.Command, args []string) error {
 
 	params, perr := parseParams(cmd)
 	if perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	}
 	if v, ok := paramString(params, "resourceName"); ok && v != "" {
 		resourceName = v

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1708,7 +1708,7 @@ func runDocsSetParagraphStyle(cmd *cobra.Command, args []string) error {
 			"HEADING_4": true, "HEADING_5": true, "HEADING_6": true,
 		}
 		if !validStyles[style] {
-			return p.PrintError(fmt.Errorf("invalid style %q; use NORMAL_TEXT, TITLE, SUBTITLE, or HEADING_1..HEADING_6", style))
+			return usageErrorf("invalid style %q; use NORMAL_TEXT, TITLE, SUBTITLE, or HEADING_1..HEADING_6", style)
 		}
 		paraStyle.NamedStyleType = style
 		fields = append(fields, "namedStyleType")
@@ -1717,7 +1717,7 @@ func runDocsSetParagraphStyle(cmd *cobra.Command, args []string) error {
 	if direction != "" {
 		validDirs := map[string]bool{"LEFT_TO_RIGHT": true, "RIGHT_TO_LEFT": true}
 		if !validDirs[direction] {
-			return p.PrintError(fmt.Errorf("invalid direction %q; use LEFT_TO_RIGHT or RIGHT_TO_LEFT", direction))
+			return usageErrorf("invalid direction %q; use LEFT_TO_RIGHT or RIGHT_TO_LEFT", direction)
 		}
 		paraStyle.Direction = direction
 		fields = append(fields, "direction")
@@ -1814,7 +1814,7 @@ func runDocsAddList(cmd *cobra.Command, args []string) error {
 	case "numbered":
 		bulletPreset = "NUMBERED_DECIMAL_NESTED"
 	default:
-		return p.PrintError(fmt.Errorf("invalid list type: %s (use 'bullet' or 'numbered')", listType))
+		return usageErrorf("invalid list type: %s (use 'bullet' or 'numbered')", listType)
 	}
 
 	loc := &docs.Location{Index: position}

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1143,7 +1143,7 @@ func runDocsInsert(cmd *cobra.Command, args []string) error {
 
 	// Validate position (skip for richformat which provides its own positions)
 	if contentFormat != "richformat" && position < 1 {
-		return p.PrintError(fmt.Errorf("position must be >= 1"))
+		return usageErrorf("position must be >= 1")
 	}
 	if contentFormat == "richformat" && cmd.Flags().Changed("at") {
 		fmt.Fprintln(os.Stderr, "warning: --at is ignored when --content-format is richformat")
@@ -1270,10 +1270,10 @@ func runDocsDelete(cmd *cobra.Command, args []string) error {
 
 	// Validate positions
 	if from < 1 {
-		return p.PrintError(fmt.Errorf("--from must be >= 1"))
+		return usageErrorf("--from must be >= 1")
 	}
 	if to <= from {
-		return p.PrintError(fmt.Errorf("--to must be greater than --from"))
+		return usageErrorf("--to must be greater than --from")
 	}
 
 	// Resolve tab ID
@@ -1342,10 +1342,10 @@ func runDocsReplaceContent(cmd *cobra.Command, args []string) error {
 
 	// Validate: exactly one of --text or --file must be provided
 	if text == "" && filePath == "" {
-		return p.PrintError(fmt.Errorf("either --text or --file is required"))
+		return usageErrorf("either --text or --file is required")
 	}
 	if text != "" && filePath != "" {
-		return p.PrintError(fmt.Errorf("--text and --file are mutually exclusive"))
+		return usageErrorf("--text and --file are mutually exclusive")
 	}
 
 	// Read content from file if --file provided
@@ -1358,7 +1358,7 @@ func runDocsReplaceContent(cmd *cobra.Command, args []string) error {
 	}
 
 	if text == "" {
-		return p.PrintError(fmt.Errorf("replacement text cannot be empty"))
+		return usageErrorf("replacement text cannot be empty")
 	}
 
 	// Get document to find content end index
@@ -1445,13 +1445,13 @@ func runDocsAddTable(cmd *cobra.Command, args []string) error {
 
 	// Validate
 	if position < 1 {
-		return p.PrintError(fmt.Errorf("--at must be >= 1"))
+		return usageErrorf("--at must be >= 1")
 	}
 	if rows < 1 {
-		return p.PrintError(fmt.Errorf("--rows must be >= 1"))
+		return usageErrorf("--rows must be >= 1")
 	}
 	if cols < 1 {
-		return p.PrintError(fmt.Errorf("--cols must be >= 1"))
+		return usageErrorf("--cols must be >= 1")
 	}
 
 	// Resolve tab ID
@@ -1546,10 +1546,10 @@ func runDocsFormat(cmd *cobra.Command, args []string) error {
 	tabQuery, _ := cmd.Flags().GetString("tab")
 
 	if from < 1 {
-		return p.PrintError(fmt.Errorf("--from must be >= 1"))
+		return usageErrorf("--from must be >= 1")
 	}
 	if to <= from {
-		return p.PrintError(fmt.Errorf("--to must be greater than --from"))
+		return usageErrorf("--to must be greater than --from")
 	}
 
 	// Resolve tab ID
@@ -1609,7 +1609,7 @@ func runDocsFormat(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fields) == 0 {
-		return p.PrintError(fmt.Errorf("no formatting options specified; use --bold, --italic, --font-size, --color, or --font-family"))
+		return usageErrorf("no formatting options specified; use --bold, --italic, --font-size, --color, or --font-family")
 	}
 
 	rng := &docs.Range{
@@ -1669,10 +1669,10 @@ func runDocsSetParagraphStyle(cmd *cobra.Command, args []string) error {
 	tabQuery, _ := cmd.Flags().GetString("tab")
 
 	if from < 1 {
-		return p.PrintError(fmt.Errorf("--from must be >= 1"))
+		return usageErrorf("--from must be >= 1")
 	}
 	if to <= from {
-		return p.PrintError(fmt.Errorf("--to must be greater than --from"))
+		return usageErrorf("--to must be greater than --from")
 	}
 
 	// Resolve tab ID
@@ -1724,7 +1724,7 @@ func runDocsSetParagraphStyle(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fields) == 0 {
-		return p.PrintError(fmt.Errorf("no style options specified; use --alignment, --line-spacing, --style, or --direction"))
+		return usageErrorf("no style options specified; use --alignment, --line-spacing, --style, or --direction")
 	}
 
 	rng := &docs.Range{
@@ -1781,7 +1781,7 @@ func runDocsAddList(cmd *cobra.Command, args []string) error {
 	tabQuery, _ := cmd.Flags().GetString("tab")
 
 	if position < 1 {
-		return p.PrintError(fmt.Errorf("--at must be >= 1"))
+		return usageErrorf("--at must be >= 1")
 	}
 
 	// Resolve tab ID
@@ -1879,10 +1879,10 @@ func runDocsRemoveList(cmd *cobra.Command, args []string) error {
 	tabQuery, _ := cmd.Flags().GetString("tab")
 
 	if from < 1 {
-		return p.PrintError(fmt.Errorf("--from must be >= 1"))
+		return usageErrorf("--from must be >= 1")
 	}
 	if to <= from {
-		return p.PrintError(fmt.Errorf("--to must be greater than --from"))
+		return usageErrorf("--to must be greater than --from")
 	}
 
 	// Resolve tab ID
@@ -2460,7 +2460,7 @@ func runDocsPinRows(cmd *cobra.Command, args []string) error {
 	count, _ := cmd.Flags().GetInt64("count")
 
 	if count < 0 {
-		return p.PrintError(fmt.Errorf("--count must be >= 0"))
+		return usageErrorf("--count must be >= 0")
 	}
 
 	tabID, err := resolveTabQueryToID(cmd, docID)
@@ -2696,10 +2696,10 @@ func runDocsAddNamedRange(cmd *cobra.Command, args []string) error {
 	to, _ := cmd.Flags().GetInt64("to")
 
 	if from < 1 {
-		return p.PrintError(fmt.Errorf("--from must be >= 1"))
+		return usageErrorf("--from must be >= 1")
 	}
 	if to <= from {
-		return p.PrintError(fmt.Errorf("--to must be greater than --from"))
+		return usageErrorf("--to must be greater than --from")
 	}
 
 	tabID, err := resolveTabQueryToID(cmd, docID)
@@ -2745,10 +2745,10 @@ func runDocsDeleteNamedRange(cmd *cobra.Command, args []string) error {
 	id, _ := cmd.Flags().GetString("id")
 
 	if name == "" && id == "" {
-		return p.PrintError(fmt.Errorf("either --name or --id is required"))
+		return usageErrorf("either --name or --id is required")
 	}
 	if name != "" && id != "" {
-		return p.PrintError(fmt.Errorf("use either --name or --id, not both"))
+		return usageErrorf("use either --name or --id, not both")
 	}
 
 	req := &docs.DeleteNamedRangeRequest{}
@@ -2778,7 +2778,7 @@ func runDocsAddFootnote(cmd *cobra.Command, args []string) error {
 	tabQuery, _ := cmd.Flags().GetString("tab")
 
 	if position < 1 {
-		return p.PrintError(fmt.Errorf("--at must be >= 1"))
+		return usageErrorf("--at must be >= 1")
 	}
 
 	loc := &docs.Location{Index: position}
@@ -2883,10 +2883,10 @@ func runDocsReplaceNamedRange(cmd *cobra.Command, args []string) error {
 	text, _ := cmd.Flags().GetString("text")
 
 	if name == "" && id == "" {
-		return p.PrintError(fmt.Errorf("either --name or --id is required"))
+		return usageErrorf("either --name or --id is required")
 	}
 	if name != "" && id != "" {
-		return p.PrintError(fmt.Errorf("use either --name or --id, not both"))
+		return usageErrorf("use either --name or --id, not both")
 	}
 
 	req := &docs.ReplaceNamedRangeContentRequest{
@@ -2940,7 +2940,7 @@ func runDocsUpdateStyle(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fields) == 0 {
-		return p.PrintError(fmt.Errorf("no margin options specified; use --margin-top, --margin-bottom, --margin-left, or --margin-right"))
+		return usageErrorf("no margin options specified; use --margin-top, --margin-bottom, --margin-left, or --margin-right")
 	}
 
 	requests := []*docs.Request{
@@ -2989,7 +2989,7 @@ func runDocsUpdateSectionStyle(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fields) == 0 {
-		return p.PrintError(fmt.Errorf("no section style options specified"))
+		return usageErrorf("no section style options specified")
 	}
 
 	tabID, err := resolveTabQueryToID(cmd, docID)
@@ -3066,7 +3066,7 @@ func runDocsUpdateTableCellStyle(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fields) == 0 {
-		return p.PrintError(fmt.Errorf("no cell style options specified; use --bg-color or --padding"))
+		return usageErrorf("no cell style options specified; use --bg-color or --padding")
 	}
 
 	loc := &docs.Location{Index: tableStart}

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1123,8 +1123,22 @@ func runDocsAppend(cmd *cobra.Command, args []string) error {
 
 func runDocsInsert(cmd *cobra.Command, args []string) error {
 	p := GetPrinter()
-	ctx := context.Background()
 
+	docID := args[0]
+	text, _ := cmd.Flags().GetString("text")
+	position, _ := cmd.Flags().GetInt64("at")
+	contentFormat, _ := cmd.Flags().GetString("content-format")
+	tabQuery, _ := cmd.Flags().GetString("tab")
+
+	// Validate position before auth so invalid CLI input maps to ExitUsage.
+	if contentFormat != "richformat" && position < 1 {
+		return usageErrorf("position must be >= 1")
+	}
+	if contentFormat == "richformat" && cmd.Flags().Changed("at") {
+		fmt.Fprintln(os.Stderr, "warning: --at is ignored when --content-format is richformat")
+	}
+
+	ctx := context.Background()
 	factory, err := client.NewFactory(ctx)
 	if err != nil {
 		return p.PrintError(err)
@@ -1133,20 +1147,6 @@ func runDocsInsert(cmd *cobra.Command, args []string) error {
 	svc, err := factory.Docs()
 	if err != nil {
 		return p.PrintError(err)
-	}
-
-	docID := args[0]
-	text, _ := cmd.Flags().GetString("text")
-	position, _ := cmd.Flags().GetInt64("at")
-	contentFormat, _ := cmd.Flags().GetString("content-format")
-	tabQuery, _ := cmd.Flags().GetString("tab")
-
-	// Validate position (skip for richformat which provides its own positions)
-	if contentFormat != "richformat" && position < 1 {
-		return usageErrorf("position must be >= 1")
-	}
-	if contentFormat == "richformat" && cmd.Flags().Changed("at") {
-		fmt.Fprintln(os.Stderr, "warning: --at is ignored when --content-format is richformat")
 	}
 
 	// Resolve tab ID if --tab provided

--- a/cmd/drive.go
+++ b/cmd/drive.go
@@ -1380,7 +1380,7 @@ func runDriveConvert(cmd *cobra.Command, args []string) error {
 		var ok bool
 		targetMime, ok = formatToGoogleMime[toFormat]
 		if !ok {
-			return p.PrintError(fmt.Errorf("unsupported format %q; use docs, sheets, or slides", toFormat))
+			return usageErrorf("unsupported format %q; use docs, sheets, or slides", toFormat)
 		}
 	} else {
 		// Auto-detect from source file MIME type
@@ -1394,7 +1394,7 @@ func runDriveConvert(cmd *cobra.Command, args []string) error {
 		var ok bool
 		targetMime, ok = officeToGoogleMime[src.MimeType]
 		if !ok {
-			return p.PrintError(fmt.Errorf("unsupported source MIME type %q; use --to to specify target format", src.MimeType))
+			return usageErrorf("unsupported source MIME type %q; use --to to specify target format", src.MimeType)
 		}
 		if name == "" {
 			name = src.Name

--- a/cmd/drive.go
+++ b/cmd/drive.go
@@ -2588,12 +2588,12 @@ func runDriveActivity(cmd *cobra.Command, args []string) error {
 
 	// Validate mutual exclusivity
 	if itemID != "" && folderID != "" {
-		return p.PrintError(fmt.Errorf("--item-id and --folder-id are mutually exclusive"))
+		return usageErrorf("--item-id and --folder-id are mutually exclusive")
 	}
 
 	// Validate --days
 	if days < 0 {
-		return p.PrintError(fmt.Errorf("--days must be non-negative"))
+		return usageErrorf("--days must be non-negative")
 	}
 
 	req := &driveactivity.QueryDriveActivityRequest{

--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -179,6 +179,35 @@ func TestResolveExitError_CobraEndToEnd_UnknownFlag(t *testing.T) {
 	}
 }
 
+// TestResolveExitError_EndToEnd_MalformedParams covers the round-7 fix:
+// malformed --params JSON must exit ExitUsage (2), not 1. parseParams
+// errors are wrapped via usageErrorf at every callsite.
+func TestResolveExitError_EndToEnd_MalformedParams(t *testing.T) {
+	cmd := findSubcommand(peopleCmd, "get")
+	if cmd == nil {
+		t.Fatal("people get command not registered")
+	}
+	if err := cmd.Flags().Set("params", "{not valid json"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cmd.Flags().Set("params", "") })
+
+	oldStderr := os.Stderr
+	devnull, _ := os.Open(os.DevNull)
+	os.Stderr = devnull
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		_ = devnull.Close()
+	})
+
+	err := cmd.RunE(cmd, []string{"people/c123"})
+	var resolverErr bytes.Buffer
+	code := resolveExitError(err, &resolverErr)
+	if code != ExitUsage {
+		t.Errorf("expected ExitUsage (2) for malformed --params, got %d", code)
+	}
+}
+
 // TestResolveExitError_EndToEnd_RealCommandUsageValidation exercises a
 // real `gws` command path end-to-end. people get validates resourceName
 // BEFORE creating an API client (per the round-9 reorder), so the test

--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/omriariav/workspace-cli/internal/printer"
+	"github.com/spf13/cobra"
 	"google.golang.org/api/googleapi"
 )
 
@@ -120,6 +121,116 @@ func TestResolveExitError_CobraUsageMapsToTwoAndWritesStderr(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "Error: unknown flag: --bogus") {
 		t.Errorf("expected Cobra error on stderr, got %q", out)
+	}
+}
+
+// TestResolveExitError_UnwrappedRuntimeErrorMapsToOne verifies that an
+// unprinted error which is NOT a Cobra usage error (e.g. a RunE returning
+// a write error from p.Print) maps to ExitError, not ExitUsage. This is
+// the round-3 fix — previously every non-AlreadyPrintedError mapped to 2.
+func TestResolveExitError_UnwrappedRuntimeErrorMapsToOne(t *testing.T) {
+	var buf bytes.Buffer
+	runtimeErr := fmt.Errorf("write /dev/stdout: broken pipe")
+	if got := resolveExitError(runtimeErr, &buf); got != ExitError {
+		t.Errorf("expected ExitError (1) for unwrapped runtime error, got %d", got)
+	}
+	if !strings.Contains(buf.String(), "broken pipe") {
+		t.Errorf("expected stderr to include error message, got %q", buf.String())
+	}
+}
+
+// TestResolveExitError_CobraEndToEnd_UnknownFlag exercises a real Cobra
+// command tree end-to-end so we catch regressions in SilenceUsage and the
+// usage-error classification. Uses an isolated *cobra.Command so we don't
+// touch the package-level rootCmd.
+func TestResolveExitError_CobraEndToEnd_UnknownFlag(t *testing.T) {
+	root := &cobra.Command{
+		Use:           "test-root",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	leaf := &cobra.Command{
+		Use:  "leaf",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(leaf)
+	root.SetArgs([]string{"leaf", "--bogus"})
+
+	// Capture root's own stderr/usage outputs (Cobra writes usage via
+	// SetErr / SetOut). SilenceUsage:true should keep these empty.
+	var cobraOut, cobraErr bytes.Buffer
+	root.SetOut(&cobraOut)
+	root.SetErr(&cobraErr)
+
+	var resolverErr bytes.Buffer
+	code := resolveExitError(root.Execute(), &resolverErr)
+
+	if code != ExitUsage {
+		t.Errorf("expected ExitUsage (2) for unknown flag, got %d", code)
+	}
+	if !strings.Contains(resolverErr.String(), "unknown flag") {
+		t.Errorf("expected resolver stderr to mention unknown flag, got %q", resolverErr.String())
+	}
+	// Auto-usage dump must be suppressed.
+	if strings.Contains(cobraErr.String(), "Usage:") || strings.Contains(cobraOut.String(), "Usage:") {
+		t.Errorf("expected no Cobra usage dump under SilenceUsage; got out=%q err=%q", cobraOut.String(), cobraErr.String())
+	}
+}
+
+// TestResolveExitError_CobraEndToEnd_BadArgs covers the other common
+// Cobra validation path (cobra.ExactArgs).
+func TestResolveExitError_CobraEndToEnd_BadArgs(t *testing.T) {
+	root := &cobra.Command{Use: "test-root", SilenceErrors: true, SilenceUsage: true}
+	leaf := &cobra.Command{
+		Use:  "leaf",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error { return nil },
+	}
+	root.AddCommand(leaf)
+	root.SetArgs([]string{"leaf"}) // missing required arg
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+
+	var resolverErr bytes.Buffer
+	code := resolveExitError(root.Execute(), &resolverErr)
+	if code != ExitUsage {
+		t.Errorf("expected ExitUsage (2) for missing arg, got %d", code)
+	}
+	if !strings.Contains(resolverErr.String(), "accepts") {
+		t.Errorf("expected stderr to mention 'accepts ... arg(s)', got %q", resolverErr.String())
+	}
+}
+
+func TestIsCobraUsageError(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"unknown command \"foo\" for \"gws\"", true},
+		{"unknown flag: --bogus", true},
+		{"unknown shorthand flag: 'x'", true},
+		{"flag needs an argument: --to", true},
+		{"invalid argument \"abc\" for \"--max\"", true},
+		{"required flag(s) \"to\" not set", true},
+		{"accepts 1 arg(s), received 0", true},
+		{"requires at least 1 arg(s)", true},
+		{"requires exactly 2 arg(s)", true},
+		{"subcommand is required", true},
+
+		{"failed to get person: googleapi: Error 403", false},
+		{"write /dev/stdout: broken pipe", false},
+		{"something random", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		got := isCobraUsageError(fmt.Errorf("%s", c.msg))
+		if c.msg == "" {
+			got = isCobraUsageError(nil)
+		}
+		if got != c.want {
+			t.Errorf("isCobraUsageError(%q) = %v, want %v", c.msg, got, c.want)
+		}
 	}
 }
 

--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -202,6 +202,25 @@ func TestResolveExitError_CobraEndToEnd_BadArgs(t *testing.T) {
 	}
 }
 
+// TestResolveExitError_UsageErrorfMapsToTwo verifies that the runtime
+// input-validation helper produces the same exit code as Cobra's own
+// usage errors. usageErrorf already wrote to stderr, so resolveExitError
+// must NOT re-print.
+func TestResolveExitError_UsageErrorfMapsToTwo(t *testing.T) {
+	// Simulate what usageErrorf returns (its stderr write is a side
+	// effect we don't drive here).
+	wrapped := &printer.AlreadyPrintedError{Err: &usageError{msg: "people get: resourceName is required"}}
+
+	var buf bytes.Buffer
+	code := resolveExitError(wrapped, &buf)
+	if code != ExitUsage {
+		t.Errorf("expected ExitUsage (2) for usageError, got %d", code)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no extra stderr write (usageErrorf already wrote), got %q", buf.String())
+	}
+}
+
 func TestIsCobraUsageError(t *testing.T) {
 	cases := []struct {
 		msg  string

--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+)
+
+func TestExitCodeForError_GenericError(t *testing.T) {
+	err := errors.New("something failed")
+	if got := exitCodeForError(err); got != ExitError {
+		t.Errorf("expected ExitError (1), got %d", got)
+	}
+}
+
+func TestExitCodeForError_Auth401(t *testing.T) {
+	err := &googleapi.Error{Code: 401, Message: "unauthorized"}
+	if got := exitCodeForError(err); got != ExitAuth {
+		t.Errorf("expected ExitAuth (3), got %d", got)
+	}
+}
+
+func TestExitCodeForError_Auth403(t *testing.T) {
+	err := &googleapi.Error{Code: 403, Message: "forbidden"}
+	if got := exitCodeForError(err); got != ExitAuth {
+		t.Errorf("expected ExitAuth (3), got %d", got)
+	}
+}
+
+func TestExitCodeForError_Transient429(t *testing.T) {
+	err := &googleapi.Error{Code: 429, Message: "rate limited"}
+	if got := exitCodeForError(err); got != ExitTransient {
+		t.Errorf("expected ExitTransient (4), got %d", got)
+	}
+}
+
+func TestExitCodeForError_Transient500(t *testing.T) {
+	err := &googleapi.Error{Code: 500, Message: "internal error"}
+	if got := exitCodeForError(err); got != ExitTransient {
+		t.Errorf("expected ExitTransient (4), got %d", got)
+	}
+}
+
+func TestExitCodeForError_Transient503(t *testing.T) {
+	err := &googleapi.Error{Code: 503, Message: "service unavailable"}
+	if got := exitCodeForError(err); got != ExitTransient {
+		t.Errorf("expected ExitTransient (4), got %d", got)
+	}
+}
+
+func TestExitCodeForError_Client404(t *testing.T) {
+	err := &googleapi.Error{Code: 404, Message: "not found"}
+	if got := exitCodeForError(err); got != ExitError {
+		t.Errorf("expected ExitError (1) for 404, got %d", got)
+	}
+}
+
+func TestExitCodeForError_WrappedGoogleAPIError(t *testing.T) {
+	inner := &googleapi.Error{Code: 403, Message: "forbidden"}
+	wrapped := errors.Join(errors.New("context"), inner)
+	if got := exitCodeForError(wrapped); got != ExitAuth {
+		t.Errorf("expected ExitAuth (3) for wrapped 403, got %d", got)
+	}
+}

--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -180,30 +180,18 @@ func TestResolveExitError_CobraEndToEnd_UnknownFlag(t *testing.T) {
 }
 
 // TestResolveExitError_EndToEnd_RealCommandUsageValidation exercises a
-// real `gws` command path end-to-end: invoke chat setup-space with an
-// invalid --type (a runtime validation that uses usageErrorf), and
-// verify resolveExitError returns ExitUsage. This is the integration
-// test codex requested — it touches the actual command registry, not
-// a synthetic *cobra.Command.
+// real `gws` command path end-to-end. people get validates resourceName
+// BEFORE creating an API client (per the round-9 reorder), so the test
+// is reliable in CI environments without OAuth credentials — the
+// validation fires regardless of auth state.
 func TestResolveExitError_EndToEnd_RealCommandUsageValidation(t *testing.T) {
-	cmd := findSubcommand(chatCmd, "setup-space")
+	cmd := findSubcommand(peopleCmd, "get")
 	if cmd == nil {
-		t.Fatal("chat setup-space command not registered")
+		t.Fatal("people get command not registered")
 	}
-	if err := cmd.Flags().Set("display-name", "x"); err != nil {
-		t.Fatal(err)
-	}
-	if err := cmd.Flags().Set("type", "BOGUS_TYPE"); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		cmd.Flags().Set("display-name", "")
-		cmd.Flags().Set("type", "")
-	})
 
-	// usageErrorf writes to os.Stderr. We don't capture it here — the
-	// point of this test is the exit code, not the message format
-	// (covered elsewhere).
+	// usageErrorf writes to os.Stderr. Redirect to /dev/null to keep
+	// the test output clean; the message format is tested elsewhere.
 	oldStderr := os.Stderr
 	devnull, _ := os.Open(os.DevNull)
 	os.Stderr = devnull
@@ -212,11 +200,12 @@ func TestResolveExitError_EndToEnd_RealCommandUsageValidation(t *testing.T) {
 		_ = devnull.Close()
 	})
 
+	// No positional arg, no --params resourceName → usageErrorf path.
 	err := cmd.RunE(cmd, []string{})
 	var resolverErr bytes.Buffer
 	code := resolveExitError(err, &resolverErr)
 	if code != ExitUsage {
-		t.Errorf("expected ExitUsage (2) for invalid --type, got %d", code)
+		t.Errorf("expected ExitUsage (2) for missing resourceName, got %d", code)
 	}
 }
 
@@ -268,26 +257,36 @@ func TestIsCobraUsageError(t *testing.T) {
 		msg  string
 		want bool
 	}{
+		// Real Cobra validation messages — these must match.
 		{"unknown command \"foo\" for \"gws\"", true},
 		{"unknown flag: --bogus", true},
-		{"unknown shorthand flag: 'x'", true},
+		{"unknown shorthand flag: 'x' in -x", true},
 		{"flag needs an argument: --to", true},
-		{"invalid argument \"abc\" for \"--max\"", true},
+		{"invalid argument \"abc\" for \"--max\" flag: strconv.ParseInt: parsing \"abc\": invalid syntax", true},
 		{"required flag(s) \"to\" not set", true},
 		{"accepts 1 arg(s), received 0", true},
 		{"requires at least 1 arg(s)", true},
 		{"requires exactly 2 arg(s)", true},
 		{"subcommand is required", true},
 
+		// Runtime errors that previously would have matched the loose
+		// strings.Contains check — these MUST NOT be misclassified.
 		{"failed to get person: googleapi: Error 403", false},
 		{"write /dev/stdout: broken pipe", false},
 		{"something random", false},
+		{"this argument is invalid for our use case", false},        // contains "invalid argument" substring? no — different shape
+		{"validation failed: required flag missing in JSON", false}, // contains "required flag" but not as prefix
+		{"server says: unknown flag was set in the request", false}, // "unknown flag" not at start
+		{"the response contained subcommand is required", false},    // not exact equality
+		{"failed: accepts UTF-8 only; arg(s), received raw", false}, // contains both markers but wrong shape
 		{"", false},
 	}
 	for _, c := range cases {
-		got := isCobraUsageError(fmt.Errorf("%s", c.msg))
+		var got bool
 		if c.msg == "" {
 			got = isCobraUsageError(nil)
+		} else {
+			got = isCobraUsageError(fmt.Errorf("%s", c.msg))
 		}
 		if got != c.want {
 			t.Errorf("isCobraUsageError(%q) = %v, want %v", c.msg, got, c.want)

--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -175,6 +176,47 @@ func TestResolveExitError_CobraEndToEnd_UnknownFlag(t *testing.T) {
 	// Auto-usage dump must be suppressed.
 	if strings.Contains(cobraErr.String(), "Usage:") || strings.Contains(cobraOut.String(), "Usage:") {
 		t.Errorf("expected no Cobra usage dump under SilenceUsage; got out=%q err=%q", cobraOut.String(), cobraErr.String())
+	}
+}
+
+// TestResolveExitError_EndToEnd_RealCommandUsageValidation exercises a
+// real `gws` command path end-to-end: invoke chat setup-space with an
+// invalid --type (a runtime validation that uses usageErrorf), and
+// verify resolveExitError returns ExitUsage. This is the integration
+// test codex requested — it touches the actual command registry, not
+// a synthetic *cobra.Command.
+func TestResolveExitError_EndToEnd_RealCommandUsageValidation(t *testing.T) {
+	cmd := findSubcommand(chatCmd, "setup-space")
+	if cmd == nil {
+		t.Fatal("chat setup-space command not registered")
+	}
+	if err := cmd.Flags().Set("display-name", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("type", "BOGUS_TYPE"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cmd.Flags().Set("display-name", "")
+		cmd.Flags().Set("type", "")
+	})
+
+	// usageErrorf writes to os.Stderr. We don't capture it here — the
+	// point of this test is the exit code, not the message format
+	// (covered elsewhere).
+	oldStderr := os.Stderr
+	devnull, _ := os.Open(os.DevNull)
+	os.Stderr = devnull
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+		_ = devnull.Close()
+	})
+
+	err := cmd.RunE(cmd, []string{})
+	var resolverErr bytes.Buffer
+	code := resolveExitError(err, &resolverErr)
+	if code != ExitUsage {
+		t.Errorf("expected ExitUsage (2) for invalid --type, got %d", code)
 	}
 }
 

--- a/cmd/exit_test.go
+++ b/cmd/exit_test.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/omriariav/workspace-cli/internal/printer"
 	"google.golang.org/api/googleapi"
 )
 
@@ -61,5 +65,77 @@ func TestExitCodeForError_WrappedGoogleAPIError(t *testing.T) {
 	wrapped := errors.Join(errors.New("context"), inner)
 	if got := exitCodeForError(wrapped); got != ExitAuth {
 		t.Errorf("expected ExitAuth (3) for wrapped 403, got %d", got)
+	}
+}
+
+// --- resolveExitError: full dispatch contract ----------------------------
+
+func TestResolveExitError_NilReturnsOK(t *testing.T) {
+	var buf bytes.Buffer
+	if got := resolveExitError(nil, &buf); got != ExitOK {
+		t.Errorf("expected ExitOK for nil error, got %d", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no stderr write for nil, got %q", buf.String())
+	}
+}
+
+func TestResolveExitError_PrintedGenericMapsToOne(t *testing.T) {
+	var buf bytes.Buffer
+	printed := &printer.AlreadyPrintedError{Err: errors.New("something failed")}
+	if got := resolveExitError(printed, &buf); got != ExitError {
+		t.Errorf("expected ExitError (1) for AlreadyPrintedError, got %d", got)
+	}
+	// AlreadyPrintedError means the printer already wrote to stderr;
+	// resolveExitError must not re-print.
+	if buf.Len() != 0 {
+		t.Errorf("expected no extra stderr write for printed error, got %q", buf.String())
+	}
+}
+
+func TestResolveExitError_PrintedAuthMapsToThree(t *testing.T) {
+	var buf bytes.Buffer
+	printed := &printer.AlreadyPrintedError{Err: &googleapi.Error{Code: 403, Message: "forbidden"}}
+	if got := resolveExitError(printed, &buf); got != ExitAuth {
+		t.Errorf("expected ExitAuth (3) for printed 403, got %d", got)
+	}
+}
+
+func TestResolveExitError_PrintedTransientMapsToFour(t *testing.T) {
+	var buf bytes.Buffer
+	printed := &printer.AlreadyPrintedError{Err: &googleapi.Error{Code: 503, Message: "unavailable"}}
+	if got := resolveExitError(printed, &buf); got != ExitTransient {
+		t.Errorf("expected ExitTransient (4) for printed 503, got %d", got)
+	}
+}
+
+func TestResolveExitError_CobraUsageMapsToTwoAndWritesStderr(t *testing.T) {
+	// Plain error (not AlreadyPrintedError) simulates a Cobra arg/flag
+	// validation failure that came back from rootCmd.Execute.
+	var buf bytes.Buffer
+	usageErr := fmt.Errorf("unknown flag: --bogus")
+	if got := resolveExitError(usageErr, &buf); got != ExitUsage {
+		t.Errorf("expected ExitUsage (2) for unprinted error, got %d", got)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Error: unknown flag: --bogus") {
+		t.Errorf("expected Cobra error on stderr, got %q", out)
+	}
+}
+
+func TestResolveExitError_JoinedEncodeFailureStillMapsCorrectly(t *testing.T) {
+	// Mirrors the new "join encode error" behavior of PrintError: even
+	// if the printer's stderr encode failed, AlreadyPrintedError is
+	// still in the chain and the exit code must be correct.
+	var buf bytes.Buffer
+	chain := errors.Join(
+		&printer.AlreadyPrintedError{Err: &googleapi.Error{Code: 429, Message: "rate limited"}},
+		errors.New("stderr broken: write: broken pipe"),
+	)
+	if got := resolveExitError(chain, &buf); got != ExitTransient {
+		t.Errorf("expected ExitTransient (4) for joined error, got %d", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no stderr write for joined AlreadyPrintedError, got %q", buf.String())
 	}
 }

--- a/cmd/forms.go
+++ b/cmd/forms.go
@@ -446,10 +446,10 @@ func runFormsUpdate(cmd *cobra.Command, args []string) error {
 	hasDescription := cmd.Flags().Changed("description")
 
 	if hasFile && (hasTitle || hasDescription) {
-		return p.PrintError(fmt.Errorf("--file cannot be combined with --title or --description"))
+		return usageErrorf("--file cannot be combined with --title or --description")
 	}
 	if !hasFile && !hasTitle && !hasDescription {
-		return p.PrintError(fmt.Errorf("provide --file, --title, or --description"))
+		return usageErrorf("provide --file, --title, or --description")
 	}
 
 	ctx := context.Background()

--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -1709,7 +1709,7 @@ func runGmailForward(cmd *cobra.Command, args []string) error {
 			filePath := filepath.Join(attDir, filename)
 			// Verify the resolved path is still under tmpDir
 			if resolved, err := filepath.Abs(filePath); err != nil || !strings.HasPrefix(resolved, tmpDir) {
-				return p.PrintError(fmt.Errorf("unsafe attachment filename %q", att.Filename))
+				return usageErrorf("unsafe attachment filename %q", att.Filename)
 			}
 			if err := os.WriteFile(filePath, decoded, 0600); err != nil {
 				return p.PrintError(fmt.Errorf("failed to write attachment %q: %w", filename, err))

--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -1277,7 +1277,7 @@ func runGmailThread(cmd *cobra.Command, args []string) error {
 		threadID = v
 	}
 	if threadID == "" {
-		return p.PrintError(fmt.Errorf("gmail thread: a thread id is required (positional arg or --params id)"))
+		return usageErrorf("gmail thread: a thread id is required (positional arg or --params id)")
 	}
 
 	ctx := context.Background()
@@ -1356,7 +1356,7 @@ func runGmailThreadRaw(cmd *cobra.Command, svc *gmail.Service, threadID string) 
 		threadID = v
 	}
 	if threadID == "" {
-		return p.PrintError(fmt.Errorf("gmail thread: a thread id is required (positional arg or --params id)"))
+		return usageErrorf("gmail thread: a thread id is required (positional arg or --params id)")
 	}
 	format := "full"
 	if v, ok := paramString(params, "format"); ok && v != "" {

--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -614,7 +614,7 @@ func runGmailListRaw(cmd *cobra.Command, svc *gmail.Service, query string, maxRe
 	p := GetPrinter()
 	params, perr := parseParams(cmd)
 	if perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	}
 	// Raw mode preserves the API response verbatim. The CLI's --max
 	// default would otherwise slice a verbatim page, breaking the
@@ -1271,7 +1271,7 @@ func runGmailThread(cmd *cobra.Command, args []string) error {
 	}
 	params, perr := parseParams(cmd)
 	if perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	}
 	if v, ok := paramString(params, "id"); ok && v != "" {
 		threadID = v
@@ -1348,7 +1348,7 @@ func runGmailThreadRaw(cmd *cobra.Command, svc *gmail.Service, threadID string) 
 	p := GetPrinter()
 	params, perr := parseParams(cmd)
 	if perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	}
 
 	// --params overrides: id (resource path), format, metadataHeaders.

--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -1116,7 +1116,7 @@ func runGmailLabel(cmd *cobra.Command, args []string) error {
 	removeStr, _ := cmd.Flags().GetString("remove")
 
 	if addStr == "" && removeStr == "" {
-		return p.PrintError(fmt.Errorf("at least one of --add or --remove is required"))
+		return usageErrorf("at least one of --add or --remove is required")
 	}
 
 	// Fetch label map once for both add and remove
@@ -1938,7 +1938,7 @@ func runGmailBatchModify(cmd *cobra.Command, args []string) error {
 	removeLabelsStr, _ := cmd.Flags().GetString("remove-labels")
 
 	if addLabelsStr == "" && removeLabelsStr == "" {
-		return p.PrintError(fmt.Errorf("at least one of --add-labels or --remove-labels is required"))
+		return usageErrorf("at least one of --add-labels or --remove-labels is required")
 	}
 
 	ids := strings.Split(idsStr, ",")

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -63,7 +63,7 @@ func runGroupsList(cmd *cobra.Command, args []string) error {
 	userEmail, _ := cmd.Flags().GetString("user-email")
 
 	if domain != "" && userEmail != "" {
-		return p.PrintError(fmt.Errorf("--domain and --user-email are mutually exclusive"))
+		return usageErrorf("--domain and --user-email are mutually exclusive")
 	}
 
 	call := svc.Groups.List()

--- a/cmd/gws/main.go
+++ b/cmd/gws/main.go
@@ -1,13 +1,7 @@
 package main
 
-import (
-	"os"
-
-	"github.com/omriariav/workspace-cli/cmd"
-)
+import "github.com/omriariav/workspace-cli/cmd"
 
 func main() {
-	if err := cmd.Execute(); err != nil {
-		os.Exit(1)
-	}
+	_ = cmd.Execute()
 }

--- a/cmd/people.go
+++ b/cmd/people.go
@@ -8,7 +8,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/omriariav/workspace-cli/internal/client"
@@ -65,7 +64,7 @@ func runPeopleGet(cmd *cobra.Command, args []string) error {
 		hasResource = true
 	}
 	if !hasResource {
-		return p.PrintError(errors.New("people get: resourceName is required (positional arg or --params resourceName)"))
+		return usageErrorf("people get: resourceName is required (positional arg or --params resourceName)")
 	}
 
 	ctx := context.Background()
@@ -98,7 +97,7 @@ func runPeopleGetWithSvc(cmd *cobra.Command, svc *people.Service, args []string)
 		resourceName = v
 	}
 	if resourceName == "" {
-		return p.PrintError(errors.New("people get: resourceName is required (positional arg or --params resourceName)"))
+		return usageErrorf("people get: resourceName is required (positional arg or --params resourceName)")
 	}
 
 	pf, _ := cmd.Flags().GetString("person-fields")

--- a/cmd/people.go
+++ b/cmd/people.go
@@ -57,7 +57,7 @@ func runPeopleGet(cmd *cobra.Command, args []string) error {
 	// instead of after OAuth/config failures.
 	params, perr := parseParams(cmd)
 	if perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	}
 	hasResource := len(args) > 0 && args[0] != ""
 	if v, ok := paramString(params, "resourceName"); ok && v != "" {
@@ -86,7 +86,7 @@ func runPeopleGetWithSvc(cmd *cobra.Command, svc *people.Service, args []string)
 	p := GetPrinter()
 	params, perr := parseParams(cmd)
 	if perr != nil {
-		return p.PrintError(perr)
+		return usageErrorf("%v", perr)
 	}
 
 	resourceName := ""

--- a/cmd/raw_runners_test.go
+++ b/cmd/raw_runners_test.go
@@ -488,15 +488,37 @@ func TestRunPeopleGet_MissingResourceNameErrors(t *testing.T) {
 	defer cleanup()
 
 	cmd := newPeopleGetCmd(t, nil)
-	// Per the printer-error convention, the runner emits a structured
-	// error object via the printer and returns the printer's nil. The
-	// error message must show up on stdout.
-	out, _ := captureStdout(t, func() error {
-		return runPeopleGetWithSvc(cmd, svc, nil)
+	// PrintError writes to stderr per #190.
+	errOut := captureStderrStr(t, func() {
+		_ = runPeopleGetWithSvc(cmd, svc, nil)
 	})
-	if !strings.Contains(out, "resourceName is required") {
-		t.Errorf("expected structured error JSON on stdout, got %q", out)
+	if !strings.Contains(errOut, "resourceName is required") {
+		t.Errorf("expected structured error JSON on stderr, got %q", errOut)
 	}
+}
+
+func captureStderrStr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, r)
+	}()
+
+	fn()
+	_ = w.Close()
+	wg.Wait()
+	os.Stderr = orig
+	return buf.String()
 }
 
 func TestParseParams_RejectsTrailingJunk(t *testing.T) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,11 +90,17 @@ func Execute() error {
 	return nil
 }
 
-// executeAndResolve runs the root command, prints any unprinted errors to
-// errW, and returns the exit code. Extracted from Execute so the exit-code
-// logic is unit-testable without os.Exit.
+// executeAndResolve runs the root command and returns the exit code.
+// Errors from PrintError are mapped via exitCodeForError; Cobra usage
+// errors are printed to errW as plain text and exit ExitUsage.
 func executeAndResolve(errW io.Writer) int {
-	err := rootCmd.Execute()
+	return resolveExitError(rootCmd.Execute(), errW)
+}
+
+// resolveExitError maps a Cobra execution error to an exit code. Pure
+// function — no os.Exit, no rootCmd reference — so unit tests can drive
+// every branch of the dispatch contract.
+func resolveExitError(err error, errW io.Writer) int {
 	if err == nil {
 		return ExitOK
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,13 @@ func resolveExitError(err error, errW io.Writer) int {
 	// Printed via PrintError → already on stderr; just map the code.
 	var printed *printer.AlreadyPrintedError
 	if errors.As(err, &printed) {
+		// Runtime input-validation paths wrap their message in
+		// usageError so the user sees the same exit code (2) and
+		// format (plain text) as Cobra's own arg/flag errors.
+		var ue *usageError
+		if errors.As(err, &ue) {
+			return ExitUsage
+		}
 		return exitCodeForError(err)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/omriariav/workspace-cli/internal/updatecheck"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"google.golang.org/api/googleapi"
 )
 
 var (
@@ -28,7 +30,9 @@ var rootCmd = &cobra.Command{
 It provides structured, token-efficient access to Gmail, Calendar, Drive,
 Docs, Sheets, Slides, Tasks, Chat, Forms, Contacts, Groups, Keep,
 and Custom Search.`,
+	SilenceErrors: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		cmd.SilenceUsage = true
 		emitVersionNotice(cmd, os.Stderr, quiet, os.Getenv("GWS_NO_UPDATE_CHECK") != "")
 	},
 }
@@ -62,8 +66,53 @@ func emitVersionNotice(cmd *cobra.Command, w io.Writer, quietFlag, suppressEnv b
 	}
 }
 
+// Exit codes per the #190 contract:
+//
+//	0 — success
+//	1 — generic API / runtime error
+//	2 — CLI usage error (wrong args, unknown flag)
+//	3 — auth failure (HTTP 401 / 403)
+//	4 — transient / retryable (HTTP 429, 5xx)
+const (
+	ExitOK        = 0
+	ExitError     = 1
+	ExitUsage     = 2
+	ExitAuth      = 3
+	ExitTransient = 4
+)
+
 func Execute() error {
-	return rootCmd.Execute()
+	err := rootCmd.Execute()
+	if err == nil {
+		return nil
+	}
+
+	// If the error was already printed by a Printer.PrintError call,
+	// just map the exit code. Otherwise it is a Cobra-level usage error
+	// that needs to be emitted.
+	var printed *printer.AlreadyPrintedError
+	if !errors.As(err, &printed) {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		os.Exit(ExitUsage)
+	}
+
+	os.Exit(exitCodeForError(err))
+	return nil // unreachable
+}
+
+// exitCodeForError maps a Go error to the appropriate CLI exit code by
+// inspecting the underlying googleapi.Error HTTP status.
+func exitCodeForError(err error) int {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		switch {
+		case apiErr.Code == 401 || apiErr.Code == 403:
+			return ExitAuth
+		case apiErr.Code == 429 || apiErr.Code >= 500:
+			return ExitTransient
+		}
+	}
+	return ExitError
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,23 +81,34 @@ const (
 	ExitTransient = 4
 )
 
+// Execute runs the root command and exits with the appropriate code.
 func Execute() error {
+	code := executeAndResolve(os.Stderr)
+	if code != ExitOK {
+		os.Exit(code)
+	}
+	return nil
+}
+
+// executeAndResolve runs the root command, prints any unprinted errors to
+// errW, and returns the exit code. Extracted from Execute so the exit-code
+// logic is unit-testable without os.Exit.
+func executeAndResolve(errW io.Writer) int {
 	err := rootCmd.Execute()
 	if err == nil {
-		return nil
+		return ExitOK
 	}
 
 	// If the error was already printed by a Printer.PrintError call,
 	// just map the exit code. Otherwise it is a Cobra-level usage error
-	// that needs to be emitted.
+	// (plain text, not structured JSON — by design).
 	var printed *printer.AlreadyPrintedError
 	if !errors.As(err, &printed) {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
-		os.Exit(ExitUsage)
+		fmt.Fprintf(errW, "Error: %s\n", err.Error())
+		return ExitUsage
 	}
 
-	os.Exit(exitCodeForError(err))
-	return nil // unreachable
+	return exitCodeForError(err)
 }
 
 // exitCodeForError maps a Go error to the appropriate CLI exit code by

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -137,33 +137,44 @@ func resolveExitError(err error, errW io.Writer) int {
 }
 
 // isCobraUsageError reports whether an error returned from rootCmd.Execute
-// came from Cobra's own arg/flag validation rather than RunE. Cobra does
-// not expose typed sentinels for these, so we match the stable message
-// prefixes Cobra emits for each validation failure.
+// came from Cobra's own arg/flag validation rather than a RunE. Cobra does
+// not expose typed sentinels for these, so we match the stable shapes
+// Cobra produces — using strict prefix/substring patterns so unrelated
+// runtime errors that happen to contain a Cobra-ish word don't get
+// misclassified as ExitUsage.
 func isCobraUsageError(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := err.Error()
+	// Prefix-only patterns. Cobra emits these at the start of the
+	// error message; a runtime error that happens to say e.g.
+	// "this argument is invalid" will not match.
 	for _, p := range cobraUsageErrorPrefixes {
-		if strings.Contains(msg, p) {
+		if strings.HasPrefix(msg, p) {
 			return true
 		}
+	}
+	// Argument-count errors from cobra.ExactArgs/MinimumNArgs/etc.
+	// Cobra renders them as "accepts N arg(s), received M".
+	if strings.HasPrefix(msg, "accepts ") && strings.Contains(msg, "arg(s), received") {
+		return true
+	}
+	if msg == "subcommand is required" {
+		return true
 	}
 	return false
 }
 
 var cobraUsageErrorPrefixes = []string{
-	"unknown command",
-	"unknown flag",
-	"unknown shorthand flag",
-	"flag needs an argument",
-	"invalid argument",
-	"required flag",
-	"subcommand is required",
-	"accepts ", // e.g. "accepts 1 arg(s), received 0"
-	"requires at least",
-	"requires exactly",
+	"unknown command \"",       // unknown command "foo" for "gws"
+	"unknown flag: ",           // unknown flag: --bogus
+	"unknown shorthand flag: ", // unknown shorthand flag: 'x' in -x
+	"flag needs an argument: ", // flag needs an argument: --to
+	`invalid argument "`,       // invalid argument "abc" for "--max" flag: ...
+	"required flag(s) ",        // required flag(s) "to" not set
+	"requires at least ",       // cobra.MinimumNArgs
+	"requires exactly ",        // pre-Cobra-1.x exact-args message
 }
 
 // exitCodeForError maps a Go error to the appropriate CLI exit code by

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/omriariav/workspace-cli/internal/config"
@@ -30,9 +31,15 @@ var rootCmd = &cobra.Command{
 It provides structured, token-efficient access to Gmail, Calendar, Drive,
 Docs, Sheets, Slides, Tasks, Chat, Forms, Contacts, Groups, Keep,
 and Custom Search.`,
+	// SilenceErrors prevents Cobra from re-printing errors we already
+	// emitted via PrintError (stderr structured JSON). SilenceUsage
+	// prevents the auto-generated help dump on validation failures —
+	// we surface a one-line "Error: ..." on stderr instead and direct
+	// users to --help. Both must be set on rootCmd (not in PreRun),
+	// since arg/flag validation runs before PersistentPreRun.
 	SilenceErrors: true,
+	SilenceUsage:  true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		cmd.SilenceUsage = true
 		emitVersionNotice(cmd, os.Stderr, quiet, os.Getenv("GWS_NO_UPDATE_CHECK") != "")
 	},
 }
@@ -105,16 +112,51 @@ func resolveExitError(err error, errW io.Writer) int {
 		return ExitOK
 	}
 
-	// If the error was already printed by a Printer.PrintError call,
-	// just map the exit code. Otherwise it is a Cobra-level usage error
-	// (plain text, not structured JSON — by design).
+	// Printed via PrintError → already on stderr; just map the code.
 	var printed *printer.AlreadyPrintedError
-	if !errors.As(err, &printed) {
-		fmt.Fprintf(errW, "Error: %s\n", err.Error())
-		return ExitUsage
+	if errors.As(err, &printed) {
+		return exitCodeForError(err)
 	}
 
-	return exitCodeForError(err)
+	// Unprinted error from rootCmd.Execute. Print it ourselves on
+	// stderr, then decide the exit code: Cobra arg/flag validation
+	// failures get ExitUsage; any other unwrapped runtime error
+	// (e.g. a RunE that forgot to call PrintError) gets ExitError.
+	fmt.Fprintf(errW, "Error: %s\n", err.Error())
+	if isCobraUsageError(err) {
+		return ExitUsage
+	}
+	return ExitError
+}
+
+// isCobraUsageError reports whether an error returned from rootCmd.Execute
+// came from Cobra's own arg/flag validation rather than RunE. Cobra does
+// not expose typed sentinels for these, so we match the stable message
+// prefixes Cobra emits for each validation failure.
+func isCobraUsageError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, p := range cobraUsageErrorPrefixes {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}
+
+var cobraUsageErrorPrefixes = []string{
+	"unknown command",
+	"unknown flag",
+	"unknown shorthand flag",
+	"flag needs an argument",
+	"invalid argument",
+	"required flag",
+	"subcommand is required",
+	"accepts ", // e.g. "accepts 1 arg(s), received 0"
+	"requires at least",
+	"requires exactly",
 }
 
 // exitCodeForError maps a Go error to the appropriate CLI exit code by

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -48,10 +48,10 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	apiKey := viper.GetString("search_api_key")
 
 	if engineID == "" {
-		return p.PrintError(fmt.Errorf("missing Search Engine ID: set GWS_SEARCH_ENGINE_ID environment variable or use --engine-id flag"))
+		return usageErrorf("missing Search Engine ID: set GWS_SEARCH_ENGINE_ID environment variable or use --engine-id flag")
 	}
 	if apiKey == "" {
-		return p.PrintError(fmt.Errorf("missing API Key: set GWS_SEARCH_API_KEY environment variable or use --api-key flag"))
+		return usageErrorf("missing API Key: set GWS_SEARCH_API_KEY environment variable or use --api-key flag")
 	}
 
 	query := args[0]
@@ -62,10 +62,10 @@ func runSearch(cmd *cobra.Command, args []string) error {
 
 	// Validate input ranges (Google Custom Search API limits)
 	if maxResults < 1 || maxResults > 10 {
-		return p.PrintError(fmt.Errorf("--max must be between 1 and 10"))
+		return usageErrorf("--max must be between 1 and 10")
 	}
 	if start < 1 || start > 100 {
-		return p.PrintError(fmt.Errorf("--start must be between 1 and 100"))
+		return usageErrorf("--start must be between 1 and 100")
 	}
 
 	// Build URL

--- a/cmd/sheets.go
+++ b/cmd/sheets.go
@@ -872,7 +872,7 @@ func runSheetsWrite(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(values) == 0 {
-		return p.PrintError(fmt.Errorf("no values provided; use --values or --values-json"))
+		return usageErrorf("no values provided; use --values or --values-json")
 	}
 
 	valueRange := &sheets.ValueRange{
@@ -918,7 +918,7 @@ func runSheetsAppend(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(values) == 0 {
-		return p.PrintError(fmt.Errorf("no values provided; use --values or --values-json"))
+		return usageErrorf("no values provided; use --values or --values-json")
 	}
 
 	valueRange := &sheets.ValueRange{
@@ -1071,7 +1071,7 @@ func runSheetsDeleteSheet(cmd *cobra.Command, args []string) error {
 			return p.PrintError(fmt.Errorf("sheet '%s' not found", sheetName))
 		}
 	} else if sheetID < 0 {
-		return p.PrintError(fmt.Errorf("must specify --name or --sheet-id"))
+		return usageErrorf("must specify --name or --sheet-id")
 	}
 
 	requests := []*sheets.Request{
@@ -1220,7 +1220,7 @@ func runSheetsDeleteRows(cmd *cobra.Command, args []string) error {
 	to, _ := cmd.Flags().GetInt64("to")
 
 	if to <= from {
-		return p.PrintError(fmt.Errorf("--to must be greater than --from"))
+		return usageErrorf("--to must be greater than --from")
 	}
 
 	sheetID, err := getSheetID(svc, spreadsheetID, sheetName)
@@ -1334,7 +1334,7 @@ func runSheetsDeleteCols(cmd *cobra.Command, args []string) error {
 	to, _ := cmd.Flags().GetInt64("to")
 
 	if to <= from {
-		return p.PrintError(fmt.Errorf("--to must be greater than --from"))
+		return usageErrorf("--to must be greater than --from")
 	}
 
 	sheetID, err := getSheetID(svc, spreadsheetID, sheetName)
@@ -1931,7 +1931,7 @@ func runSheetsFormat(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fields) == 0 {
-		return p.PrintError(fmt.Errorf("no formatting options specified; use --bold, --italic, --bg-color, --color, or --font-size"))
+		return usageErrorf("no formatting options specified; use --bold, --italic, --bg-color, --color, or --font-size")
 	}
 
 	requests := []*sheets.Request{
@@ -2099,7 +2099,7 @@ func runSheetsFreeze(cmd *cobra.Command, args []string) error {
 	freezeCols, _ := cmd.Flags().GetInt64("cols")
 
 	if !cmd.Flags().Changed("rows") && !cmd.Flags().Changed("cols") {
-		return p.PrintError(fmt.Errorf("specify --rows and/or --cols to freeze"))
+		return usageErrorf("specify --rows and/or --cols to freeze")
 	}
 
 	sheetID, err := getSheetID(svc, spreadsheetID, sheetName)

--- a/cmd/sheets.go
+++ b/cmd/sheets.go
@@ -2254,7 +2254,7 @@ func runSheetsBatchWrite(cmd *cobra.Command, args []string) error {
 	valueInput, _ := cmd.Flags().GetString("value-input")
 
 	if len(ranges) != len(valuesStrs) {
-		return p.PrintError(fmt.Errorf("number of --ranges flags (%d) must match number of --values flags (%d)", len(ranges), len(valuesStrs)))
+		return usageErrorf("number of --ranges flags (%d) must match number of --values flags (%d)", len(ranges), len(valuesStrs))
 	}
 
 	data := make([]*sheets.ValueRange, 0, len(ranges))
@@ -2596,7 +2596,7 @@ func runSheetsAddChart(cmd *cobra.Command, args []string) error {
 
 	validTypes := map[string]bool{"BAR": true, "LINE": true, "AREA": true, "COLUMN": true, "SCATTER": true, "PIE": true, "COMBO": true}
 	if !validTypes[chartType] {
-		return p.PrintError(fmt.Errorf("unknown chart type: %s (valid: BAR, LINE, AREA, COLUMN, SCATTER, PIE, COMBO)", chartType))
+		return usageErrorf("unknown chart type: %s (valid: BAR, LINE, AREA, COLUMN, SCATTER, PIE, COMBO)", chartType)
 	}
 
 	_, gridRange, err := parseRange(svc, spreadsheetID, dataRange)
@@ -2612,7 +2612,7 @@ func runSheetsAddChart(cmd *cobra.Command, args []string) error {
 	if chartType == "PIE" {
 		// PIE: first column = labels (domain), remaining columns = data (series)
 		if gridRange.EndColumnIndex-gridRange.StartColumnIndex < 2 {
-			return p.PrintError(fmt.Errorf("PIE chart requires at least 2 columns (labels + data), got range with %d column(s)", gridRange.EndColumnIndex-gridRange.StartColumnIndex))
+			return usageErrorf("PIE chart requires at least 2 columns (labels + data), got range with %d column(s)", gridRange.EndColumnIndex-gridRange.StartColumnIndex)
 		}
 		domainRange := &sheets.GridRange{
 			SheetId:          gridRange.SheetId,

--- a/cmd/sheets.go
+++ b/cmd/sheets.go
@@ -2825,7 +2825,7 @@ func runSheetsAddConditionalFormat(cmd *cobra.Command, args []string) error {
 
 	needsValue := map[string]bool{">": true, "<": true, "=": true, "!=": true, "contains": true, "not-contains": true, "formula": true}
 	if needsValue[rule] && value == "" {
-		return p.PrintError(fmt.Errorf("--value is required for rule type %q", rule))
+		return usageErrorf("--value is required for rule type %q", rule)
 	}
 
 	ctx := context.Background()
@@ -3028,7 +3028,7 @@ func runSheetsDeleteConditionalFormat(cmd *cobra.Command, args []string) error {
 	// Validate flags before creating API client
 	index, _ := cmd.Flags().GetInt64("index")
 	if index < 0 {
-		return p.PrintError(fmt.Errorf("--index must be >= 0, got %d", index))
+		return usageErrorf("--index must be >= 0, got %d", index)
 	}
 
 	ctx := context.Background()

--- a/cmd/slides.go
+++ b/cmd/slides.go
@@ -2438,17 +2438,6 @@ func runSlidesUpdateTableCell(cmd *cobra.Command, args []string) error {
 
 func runSlidesUpdateTableBorder(cmd *cobra.Command, args []string) error {
 	p := GetPrinter()
-	ctx := context.Background()
-
-	factory, err := client.NewFactory(ctx)
-	if err != nil {
-		return p.PrintError(err)
-	}
-
-	svc, err := factory.Slides()
-	if err != nil {
-		return p.PrintError(err)
-	}
 
 	presentationID := args[0]
 	tableID, _ := cmd.Flags().GetString("table-id")
@@ -2458,6 +2447,25 @@ func runSlidesUpdateTableBorder(cmd *cobra.Command, args []string) error {
 	colorHex, _ := cmd.Flags().GetString("color")
 	width, _ := cmd.Flags().GetFloat64("width")
 	style, _ := cmd.Flags().GetString("style")
+
+	// Validate enum-shaped flags before auth so invalid CLI input maps
+	// to ExitUsage, not an auth failure.
+	switch border {
+	case "all", "top", "bottom", "left", "right":
+	default:
+		return usageErrorf("invalid border: %s (use top, bottom, left, right, or all)", border)
+	}
+
+	ctx := context.Background()
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Slides()
+	if err != nil {
+		return p.PrintError(err)
+	}
 
 	// Build border properties
 	borderProps := &slides.TableBorderProperties{
@@ -3072,8 +3080,25 @@ func runSlidesAddLine(cmd *cobra.Command, args []string) error {
 
 func runSlidesGroup(cmd *cobra.Command, args []string) error {
 	p := GetPrinter()
-	ctx := context.Background()
 
+	presentationID := args[0]
+	objectIDsStr, _ := cmd.Flags().GetString("object-ids")
+
+	// Trim and drop empties so inputs like "id1,,id2" or " , id1 " don't
+	// pass validation and send empty object IDs to the API.
+	rawIDs := strings.Split(objectIDsStr, ",")
+	objectIDs := make([]string, 0, len(rawIDs))
+	for _, id := range rawIDs {
+		if trimmed := strings.TrimSpace(id); trimmed != "" {
+			objectIDs = append(objectIDs, trimmed)
+		}
+	}
+
+	if len(objectIDs) < 2 {
+		return usageErrorf("at least 2 non-empty element IDs are required for grouping")
+	}
+
+	ctx := context.Background()
 	factory, err := client.NewFactory(ctx)
 	if err != nil {
 		return p.PrintError(err)
@@ -3082,18 +3107,6 @@ func runSlidesGroup(cmd *cobra.Command, args []string) error {
 	svc, err := factory.Slides()
 	if err != nil {
 		return p.PrintError(err)
-	}
-
-	presentationID := args[0]
-	objectIDsStr, _ := cmd.Flags().GetString("object-ids")
-
-	objectIDs := strings.Split(objectIDsStr, ",")
-	for i, id := range objectIDs {
-		objectIDs[i] = strings.TrimSpace(id)
-	}
-
-	if len(objectIDs) < 2 {
-		return usageErrorf("at least 2 element IDs are required for grouping")
 	}
 
 	requests := []*slides.Request{

--- a/cmd/slides.go
+++ b/cmd/slides.go
@@ -1599,25 +1599,25 @@ func runSlidesAddText(cmd *cobra.Command, args []string) error {
 		modeCount++
 	}
 	if modeCount > 1 {
-		return p.PrintError(fmt.Errorf("--object-id, --table-id, and --notes are mutually exclusive"))
+		return usageErrorf("--object-id, --table-id, and --notes are mutually exclusive")
 	}
 	if modeCount == 0 {
-		return p.PrintError(fmt.Errorf("must specify --object-id, --table-id, or --notes"))
+		return usageErrorf("must specify --object-id, --table-id, or --notes")
 	}
 
 	// Validate table cell mode requires row and col
 	if tableID != "" {
 		if row < 0 {
-			return p.PrintError(fmt.Errorf("--row is required when using --table-id (valid values: 0 or greater)"))
+			return usageErrorf("--row is required when using --table-id (valid values: 0 or greater)")
 		}
 		if col < 0 {
-			return p.PrintError(fmt.Errorf("--col is required when using --table-id (valid values: 0 or greater)"))
+			return usageErrorf("--col is required when using --table-id (valid values: 0 or greater)")
 		}
 	}
 
 	// Validate notes mode requires slide targeting
 	if notesMode && slideIDFlag == "" && slideNumber == 0 {
-		return p.PrintError(fmt.Errorf("--notes requires --slide-id or --slide-number"))
+		return usageErrorf("--notes requires --slide-id or --slide-number")
 	}
 
 	// Now create the client after validation passes
@@ -1934,15 +1934,15 @@ func runSlidesDeleteText(cmd *cobra.Command, args []string) error {
 
 	// Validate: need either --object-id or --notes
 	if objectID == "" && !notesMode {
-		return p.PrintError(fmt.Errorf("must specify --object-id or --notes"))
+		return usageErrorf("must specify --object-id or --notes")
 	}
 	if objectID != "" && notesMode {
-		return p.PrintError(fmt.Errorf("--object-id and --notes are mutually exclusive"))
+		return usageErrorf("--object-id and --notes are mutually exclusive")
 	}
 
 	// Validate notes mode requires slide targeting
 	if notesMode && slideIDFlag == "" && slideNumber == 0 {
-		return p.PrintError(fmt.Errorf("--notes requires --slide-id or --slide-number"))
+		return usageErrorf("--notes requires --slide-id or --slide-number")
 	}
 
 	ctx := context.Background()
@@ -3171,7 +3171,7 @@ func runSlidesThumbnail(cmd *cobra.Command, args []string) error {
 	validSizes := map[string]bool{"SMALL": true, "MEDIUM": true, "LARGE": true}
 	sizeUpper := strings.ToUpper(size)
 	if !validSizes[sizeUpper] {
-		return p.PrintError(fmt.Errorf("invalid size '%s': must be SMALL, MEDIUM, or LARGE", size))
+		return usageErrorf("invalid size '%s': must be SMALL, MEDIUM, or LARGE", size)
 	}
 
 	ctx := context.Background()

--- a/cmd/slides.go
+++ b/cmd/slides.go
@@ -1111,7 +1111,7 @@ func runSlidesDeleteSlide(cmd *cobra.Command, args []string) error {
 
 		slideID = presentation.Slides[slideNumber-1].ObjectId
 	} else if slideID == "" {
-		return p.PrintError(fmt.Errorf("must specify --slide-id or --slide-number"))
+		return usageErrorf("must specify --slide-id or --slide-number")
 	}
 
 	requests := []*slides.Request{
@@ -1172,7 +1172,7 @@ func runSlidesDuplicateSlide(cmd *cobra.Command, args []string) error {
 
 		slideID = presentation.Slides[slideNumber-1].ObjectId
 	} else if slideID == "" {
-		return p.PrintError(fmt.Errorf("must specify --slide-id or --slide-number"))
+		return usageErrorf("must specify --slide-id or --slide-number")
 	}
 
 	requests := []*slides.Request{
@@ -2084,7 +2084,7 @@ func runSlidesUpdateTextStyle(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fields) == 0 {
-		return p.PrintError(fmt.Errorf("no style changes specified"))
+		return usageErrorf("no style changes specified")
 	}
 
 	var textRange *slides.Range
@@ -2383,7 +2383,7 @@ func runSlidesUpdateTableCell(cmd *cobra.Command, args []string) error {
 	bgColor, _ := cmd.Flags().GetString("background-color")
 
 	if bgColor == "" {
-		return p.PrintError(fmt.Errorf("--background-color is required"))
+		return usageErrorf("--background-color is required")
 	}
 
 	color, err := parseHexColor(bgColor)
@@ -2602,7 +2602,7 @@ func runSlidesUpdateParagraphStyle(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fields) == 0 {
-		return p.PrintError(fmt.Errorf("no paragraph style changes specified"))
+		return usageErrorf("no paragraph style changes specified")
 	}
 
 	var textRange *slides.Range
@@ -2710,7 +2710,7 @@ func runSlidesUpdateShape(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(fields) == 0 {
-		return p.PrintError(fmt.Errorf("no shape properties specified"))
+		return usageErrorf("no shape properties specified")
 	}
 
 	requests := []*slides.Request{
@@ -2796,10 +2796,10 @@ func runSlidesUpdateSlideBackground(cmd *cobra.Command, args []string) error {
 
 	// Validate: must specify exactly one of --color or --image-url
 	if colorHex == "" && imageURL == "" {
-		return p.PrintError(fmt.Errorf("must specify --color or --image-url"))
+		return usageErrorf("must specify --color or --image-url")
 	}
 	if colorHex != "" && imageURL != "" {
-		return p.PrintError(fmt.Errorf("--color and --image-url are mutually exclusive"))
+		return usageErrorf("--color and --image-url are mutually exclusive")
 	}
 
 	ctx := context.Background()
@@ -3093,7 +3093,7 @@ func runSlidesGroup(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(objectIDs) < 2 {
-		return p.PrintError(fmt.Errorf("at least 2 element IDs are required for grouping"))
+		return usageErrorf("at least 2 element IDs are required for grouping")
 	}
 
 	requests := []*slides.Request{

--- a/cmd/slides.go
+++ b/cmd/slides.go
@@ -982,7 +982,7 @@ func runSlidesAddSlide(cmd *cobra.Command, args []string) error {
 			"BIG_NUMBER":                    true,
 		}
 		if !validLayouts[layout] {
-			return p.PrintError(fmt.Errorf("invalid layout '%s'. Valid layouts: BLANK, TITLE, TITLE_AND_BODY, TITLE_AND_TWO_COLUMNS, TITLE_ONLY, SECTION_HEADER, CAPTION_ONLY, MAIN_POINT, BIG_NUMBER", layout))
+			return usageErrorf("invalid layout '%s'. Valid layouts: BLANK, TITLE, TITLE_AND_BODY, TITLE_AND_TWO_COLUMNS, TITLE_ONLY, SECTION_HEADER, CAPTION_ONLY, MAIN_POINT, BIG_NUMBER", layout)
 		}
 		layoutRef = &slides.LayoutReference{
 			PredefinedLayout: layout,
@@ -1423,7 +1423,7 @@ func runSlidesAddShape(cmd *cobra.Command, args []string) error {
 
 	// Validate shape type
 	if !validShapeTypes[shapeType] {
-		return p.PrintError(fmt.Errorf("invalid shape type '%s'. Common types: RECTANGLE, ELLIPSE, TEXT_BOX, TRIANGLE, ARROW, STAR_5", shapeType))
+		return usageErrorf("invalid shape type '%s'. Common types: RECTANGLE, ELLIPSE, TEXT_BOX, TRIANGLE, ARROW, STAR_5", shapeType)
 	}
 
 	slideID, err := getSlideID(svc, presentationID, slideIDFlag, slideNumber)
@@ -2510,7 +2510,7 @@ func runSlidesUpdateTableBorder(cmd *cobra.Command, args []string) error {
 	case "right":
 		borders = []string{"RIGHT"}
 	default:
-		return p.PrintError(fmt.Errorf("invalid border: %s (use top, bottom, left, right, or all)", border))
+		return usageErrorf("invalid border: %s (use top, bottom, left, right, or all)", border)
 	}
 
 	requests := make([]*slides.Request, 0, len(borders))

--- a/cmd/slides_test.go
+++ b/cmd/slides_test.go
@@ -830,17 +830,17 @@ func TestSlidesAddTextCommand_ValidationErrors(t *testing.T) {
 				}
 			}
 
-			// Capture os.Stdout since the printer writes directly to it
-			oldStdout := os.Stdout
+			// Capture os.Stderr since PrintError writes to stderr (#190)
+			oldStderr := os.Stderr
 			r, w, _ := os.Pipe()
-			os.Stdout = w
+			os.Stderr = w
 
 			// Execute the command with a dummy presentation ID
 			_ = cmd.RunE(cmd, []string{"test-presentation-id"})
 
-			// Restore stdout and read captured output
+			// Restore stderr and read captured output
 			w.Close()
-			os.Stdout = oldStdout
+			os.Stderr = oldStderr
 			captured, _ := io.ReadAll(r)
 			output := string(captured)
 
@@ -1068,14 +1068,14 @@ func TestSlidesAddTextCommand_NotesValidation(t *testing.T) {
 				}
 			}
 
-			oldStdout := os.Stdout
+			oldStderr := os.Stderr
 			r, w, _ := os.Pipe()
-			os.Stdout = w
+			os.Stderr = w
 
 			_ = cmd.RunE(cmd, []string{"test-presentation-id"})
 
 			w.Close()
-			os.Stdout = oldStdout
+			os.Stderr = oldStderr
 			captured, _ := io.ReadAll(r)
 			output := string(captured)
 
@@ -1136,14 +1136,14 @@ func TestSlidesDeleteTextCommand_NotesValidation(t *testing.T) {
 				}
 			}
 
-			oldStdout := os.Stdout
+			oldStderr := os.Stderr
 			r, w, _ := os.Pipe()
-			os.Stdout = w
+			os.Stderr = w
 
 			_ = cmd.RunE(cmd, []string{"test-presentation-id"})
 
 			w.Close()
-			os.Stdout = oldStdout
+			os.Stderr = oldStderr
 			captured, _ := io.ReadAll(r)
 			output := string(captured)
 

--- a/cmd/tasks.go
+++ b/cmd/tasks.go
@@ -328,7 +328,7 @@ func runTasksUpdate(cmd *cobra.Command, args []string) error {
 	dueChanged := cmd.Flags().Changed("due")
 
 	if !titleChanged && !notesChanged && !dueChanged {
-		return p.PrintError(fmt.Errorf("at least one of --title, --notes, or --due is required"))
+		return usageErrorf("at least one of --title, --notes, or --due is required")
 	}
 
 	ctx := context.Background()

--- a/cmd/usage.go
+++ b/cmd/usage.go
@@ -9,6 +9,20 @@ package cmd
 // declaratively (arg counts, unknown flags); usageError covers checks
 // that depend on flag values, --params content, or any data Cobra cannot
 // validate up front.
+//
+// CONVENTION for new code:
+//   - Validating user input ("must specify X", "X is required",
+//     "--from must be >= 1", invalid enum value)  → usageErrorf(...)
+//   - Reporting state/post-condition failure ("no cache found",
+//     "document has no content", "sheet 'X' not found",
+//     "you are not an attendee", "unexpected empty response")
+//                                                  → p.PrintError(...)
+//   - Wrapping a Google API error (fmt.Errorf("failed to X: %w", err))
+//                                                  → p.PrintError(...)
+//     (exitCodeForError will map 401/403/429/5xx to 3/4 automatically)
+//
+// State-only sites intentionally exit 1, since their cause is server-
+// or file-side, not the user's invocation.
 
 import (
 	"fmt"

--- a/cmd/usage.go
+++ b/cmd/usage.go
@@ -1,0 +1,34 @@
+package cmd
+
+// Runtime input-validation errors. A handler that catches "you forgot a
+// required field" can return usageErrorf(...) to signal:
+//   - exit code = ExitUsage (2) — same as Cobra's own arg/flag errors
+//   - output    = plain text "Error: <msg>" on stderr (not structured JSON)
+//
+// This complements Cobra-level validation: Cobra catches what it can
+// declaratively (arg counts, unknown flags); usageError covers checks
+// that depend on flag values, --params content, or any data Cobra cannot
+// validate up front.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/omriariav/workspace-cli/internal/printer"
+)
+
+// usageError marks an error as a CLI-input mistake. resolveExitError
+// surfaces these as ExitUsage.
+type usageError struct{ msg string }
+
+func (e *usageError) Error() string { return e.msg }
+
+// usageErrorf prints a plain-text error line to stderr and returns
+// AlreadyPrintedError wrapping a usageError. Callsites use it exactly
+// like fmt.Errorf so the migration from "p.PrintError(fmt.Errorf(...))"
+// to "usageErrorf(...)" is a single-line swap.
+func usageErrorf(format string, args ...interface{}) error {
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintf(os.Stderr, "Error: %s\n", msg)
+	return &printer.AlreadyPrintedError{Err: &usageError{msg: msg}}
+}

--- a/cmd/validation_test.go
+++ b/cmd/validation_test.go
@@ -8,20 +8,21 @@ import (
 	"testing"
 )
 
-// captureOutput captures stdout during a function call and returns the output.
+// captureOutput captures stderr during a function call and returns the output.
+// (PrintError writes structured errors to stderr per #190.)
 func captureOutput(t *testing.T, fn func()) string {
 	t.Helper()
-	old := os.Stdout
+	old := os.Stderr
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("failed to create pipe: %v", err)
 	}
-	os.Stdout = w
+	os.Stderr = w
 
 	fn()
 
 	w.Close()
-	os.Stdout = old
+	os.Stderr = old
 
 	var buf bytes.Buffer
 	buf.ReadFrom(r)

--- a/cmd/validation_test.go
+++ b/cmd/validation_test.go
@@ -29,16 +29,29 @@ func captureOutput(t *testing.T, fn func()) string {
 	return buf.String()
 }
 
-// extractError parses JSON output and returns the "error" field if present.
+// extractError returns the error message from either format the CLI may
+// produce on stderr:
+//   - structured JSON: {"error": "..."} (runtime/API failures)
+//   - plain text:      "Error: ..."     (CLI usage errors)
+//
+// Returns "" if no recognizable error shape is found.
 func extractError(output string) string {
-	var result map[string]interface{}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &result); err != nil {
+	trim := strings.TrimSpace(output)
+	if trim == "" {
 		return ""
 	}
-	if errMsg, ok := result["error"].(string); ok {
-		return errMsg
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(trim), &result); err == nil {
+		if errMsg, ok := result["error"].(string); ok {
+			return errMsg
+		}
 	}
-	return ""
+	for _, line := range strings.Split(trim, "\n") {
+		if strings.HasPrefix(line, "Error: ") {
+			return strings.TrimPrefix(line, "Error: ")
+		}
+	}
+	return trim
 }
 
 // --- Forms validation tests ---

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -16,10 +16,10 @@ var ServiceScopes = map[string][]string{
 	"chat":     {"chat.spaces", "chat.messages", "chat.messages.create", "chat.memberships", "chat.messages.reactions", "chat.users.readstate"},
 	"forms":    {"forms.responses.readonly", "forms.body", "forms.body.readonly"},
 	"contacts": {"contacts.readonly", "contacts", "directory.readonly"},
-	// `people` is an alias for `contacts` — both surface the People API.
-	// Kept as a distinct entry so `--services people` works and scoped
-	// warnings can refer to either name interchangeably.
-	"people":        {"contacts.readonly", "contacts", "directory.readonly"},
+	// `people` surfaces the People API for `gws people get`. Includes
+	// `userinfo.profile` which the API requires for `people/me` requests.
+	// Does NOT include admin.directory.group.* — those belong to `groups`.
+	"people":        {"userinfo.profile", "contacts.readonly", "contacts", "directory.readonly"},
 	"groups":        {"admin.directory.group.readonly", "admin.directory.group.member.readonly"},
 	"keep":          {"keep.readonly", "keep"},
 	"driveactivity": {"drive.activity.readonly"},
@@ -33,7 +33,7 @@ func computeAllScopes() []string {
 	seen := make(map[string]bool)
 	var scopes []string
 	// Deterministic order: iterate known service names
-	order := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "contacts", "groups", "keep", "driveactivity", "userinfo"}
+	order := []string{"gmail", "calendar", "drive", "docs", "sheets", "slides", "tasks", "chat", "forms", "contacts", "people", "groups", "keep", "driveactivity", "userinfo"}
 	for _, svc := range order {
 		for _, s := range ServiceScopes[svc] {
 			full := scopePrefix + s

--- a/internal/printer/exit.go
+++ b/internal/printer/exit.go
@@ -1,0 +1,11 @@
+package printer
+
+// AlreadyPrintedError wraps an error that has already been emitted to
+// the error writer by a Printer. Callers (Execute, main) should NOT
+// re-print the message — only inspect it for exit-code mapping.
+type AlreadyPrintedError struct {
+	Err error
+}
+
+func (e *AlreadyPrintedError) Error() string { return e.Err.Error() }
+func (e *AlreadyPrintedError) Unwrap() error { return e.Err }

--- a/internal/printer/json.go
+++ b/internal/printer/json.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 )
 
@@ -26,12 +27,18 @@ func (p *JSONPrinter) Print(data interface{}) error {
 
 // PrintError writes a structured error to the error writer (stderr) and
 // returns the original error wrapped in AlreadyPrintedError so callers
-// propagate a non-zero exit without re-printing.
+// propagate a non-zero exit without re-printing. If the encode fails
+// (rare; broken stderr), the encode error is joined onto the returned
+// chain so it is still inspectable.
 func (p *JSONPrinter) PrintError(err error) error {
 	enc := json.NewEncoder(p.errW)
 	enc.SetIndent("", "  ")
-	_ = enc.Encode(map[string]interface{}{
+	encErr := enc.Encode(map[string]interface{}{
 		"error": err.Error(),
 	})
-	return &AlreadyPrintedError{Err: err}
+	printed := &AlreadyPrintedError{Err: err}
+	if encErr != nil {
+		return errors.Join(printed, encErr)
+	}
+	return printed
 }

--- a/internal/printer/json.go
+++ b/internal/printer/json.go
@@ -7,24 +7,31 @@ import (
 
 // JSONPrinter outputs data as indented JSON.
 type JSONPrinter struct {
-	w io.Writer
+	w    io.Writer
+	errW io.Writer
 }
 
-// NewJSONPrinter creates a new JSON printer.
-func NewJSONPrinter(w io.Writer) *JSONPrinter {
-	return &JSONPrinter{w: w}
+// NewJSONPrinter creates a new JSON printer with separate output and error
+// writers. Success data goes to w; errors go to errW.
+func NewJSONPrinter(w, errW io.Writer) *JSONPrinter {
+	return &JSONPrinter{w: w, errW: errW}
 }
 
-// Print outputs data as indented JSON.
+// Print outputs data as indented JSON to stdout.
 func (p *JSONPrinter) Print(data interface{}) error {
 	encoder := json.NewEncoder(p.w)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(data)
 }
 
-// PrintError outputs an error as JSON.
+// PrintError writes a structured error to the error writer (stderr) and
+// returns the original error wrapped in AlreadyPrintedError so callers
+// propagate a non-zero exit without re-printing.
 func (p *JSONPrinter) PrintError(err error) error {
-	return p.Print(map[string]interface{}{
+	enc := json.NewEncoder(p.errW)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(map[string]interface{}{
 		"error": err.Error(),
 	})
+	return &AlreadyPrintedError{Err: err}
 }

--- a/internal/printer/null.go
+++ b/internal/printer/null.go
@@ -13,7 +13,8 @@ func (p *NullPrinter) Print(data interface{}) error {
 	return nil
 }
 
-// PrintError discards the error.
+// PrintError suppresses output but returns the error wrapped in
+// AlreadyPrintedError so the process still exits non-zero.
 func (p *NullPrinter) PrintError(err error) error {
-	return nil
+	return &AlreadyPrintedError{Err: err}
 }

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -2,6 +2,7 @@ package printer
 
 import (
 	"io"
+	"os"
 )
 
 // Printer is the interface for output formatters.
@@ -10,14 +11,21 @@ type Printer interface {
 	PrintError(err error) error
 }
 
-// New creates a new Printer based on the format string.
+// New creates a Printer that writes success output to w and errors to
+// os.Stderr (the standard unix convention).
 func New(w io.Writer, format string) Printer {
+	return NewWithWriters(w, os.Stderr, format)
+}
+
+// NewWithWriters creates a Printer with explicit output and error writers.
+// Useful in tests to capture stderr independently.
+func NewWithWriters(w, errW io.Writer, format string) Printer {
 	switch format {
 	case "text":
-		return NewTextPrinter(w)
+		return NewTextPrinter(w, errW)
 	case "yaml":
-		return NewYAMLPrinter(w)
+		return NewYAMLPrinter(w, errW)
 	default:
-		return NewJSONPrinter(w)
+		return NewJSONPrinter(w, errW)
 	}
 }

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -500,6 +500,33 @@ func TestTextPrinter_Print_SliceOfStrings(t *testing.T) {
 	}
 }
 
+// failingWriter always returns an error on Write; used to verify that
+// PrintError surfaces encode failures via errors.Join.
+type failingWriter struct{ err error }
+
+func (f *failingWriter) Write(p []byte) (int, error) { return 0, f.err }
+
+func TestJSONPrinter_PrintError_JoinsEncodeFailure(t *testing.T) {
+	var ok bytes.Buffer
+	fw := &failingWriter{err: errors.New("disk full")}
+	p := NewJSONPrinter(&ok, fw)
+
+	printErr := p.PrintError(errors.New("api boom"))
+
+	// AlreadyPrintedError must still be present for callers that key on it.
+	var printed *AlreadyPrintedError
+	if !errors.As(printErr, &printed) {
+		t.Fatalf("expected AlreadyPrintedError in chain, got %T", printErr)
+	}
+	if !strings.Contains(printed.Err.Error(), "api boom") {
+		t.Errorf("expected original error preserved, got %v", printed.Err)
+	}
+	// And the underlying write failure must be inspectable.
+	if !strings.Contains(printErr.Error(), "disk full") {
+		t.Errorf("expected encode failure joined into chain, got %q", printErr.Error())
+	}
+}
+
 func TestTextPrinter_Print_ReflectSlice(t *testing.T) {
 	var buf bytes.Buffer
 	p := NewTextPrinter(&buf, &bytes.Buffer{})

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -47,8 +47,10 @@ func TestNullPrinter_PrintError(t *testing.T) {
 	p := NewNullPrinter()
 
 	err := errors.New("test error")
-	if printErr := p.PrintError(err); printErr != nil {
-		t.Errorf("unexpected error: %v", printErr)
+	printErr := p.PrintError(err)
+	var printed *AlreadyPrintedError
+	if !errors.As(printErr, &printed) {
+		t.Errorf("expected AlreadyPrintedError, got %T: %v", printErr, printErr)
 	}
 }
 
@@ -59,7 +61,8 @@ func TestNullPrinter_ImplementsPrinter(t *testing.T) {
 
 func TestNullPrinter_SuppressesOutput(t *testing.T) {
 	null := NewNullPrinter()
-	jsonPrinter := NewJSONPrinter(&bytes.Buffer{})
+	var errBuf bytes.Buffer
+	jsonPrinter := NewJSONPrinter(&bytes.Buffer{}, &errBuf)
 
 	data := map[string]interface{}{
 		"thread_id": "abc-123",
@@ -80,11 +83,13 @@ func TestNullPrinter_SuppressesOutput(t *testing.T) {
 
 	for _, v := range types {
 		if err, ok := v.(error); ok {
-			if printErr := null.PrintError(err); printErr != nil {
-				t.Errorf("NullPrinter.PrintError failed for %T: %v", v, printErr)
+			// PrintError now returns AlreadyPrintedError (non-nil) — that's intentional.
+			var printed *AlreadyPrintedError
+			if printErr := null.PrintError(err); !errors.As(printErr, &printed) {
+				t.Errorf("NullPrinter.PrintError: expected AlreadyPrintedError for %T, got %T", v, printErr)
 			}
-			if printErr := jsonPrinter.PrintError(err); printErr != nil {
-				t.Errorf("JSONPrinter.PrintError failed for %T: %v", v, printErr)
+			if printErr := jsonPrinter.PrintError(err); !errors.As(printErr, &printed) {
+				t.Errorf("JSONPrinter.PrintError: expected AlreadyPrintedError for %T, got %T", v, printErr)
 			}
 		} else {
 			if err := null.Print(v); err != nil {
@@ -109,8 +114,10 @@ func TestNullPrinter_HandlesLargeData(t *testing.T) {
 	if err := p.Print(largeData); err != nil {
 		t.Errorf("unexpected error with large data: %v", err)
 	}
-	if err := p.PrintError(errors.New("big error")); err != nil {
-		t.Errorf("unexpected error with PrintError: %v", err)
+	printErr := p.PrintError(errors.New("big error"))
+	var printed *AlreadyPrintedError
+	if !errors.As(printErr, &printed) {
+		t.Errorf("expected AlreadyPrintedError, got %T", printErr)
 	}
 }
 
@@ -125,7 +132,7 @@ func TestNew_YAML(t *testing.T) {
 
 func TestYAMLPrinter_Print_Map(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewYAMLPrinter(&buf)
+	p := NewYAMLPrinter(&buf, &bytes.Buffer{})
 
 	data := map[string]interface{}{
 		"name":  "test",
@@ -147,7 +154,7 @@ func TestYAMLPrinter_Print_Map(t *testing.T) {
 
 func TestYAMLPrinter_Print_Slice(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewYAMLPrinter(&buf)
+	p := NewYAMLPrinter(&buf, &bytes.Buffer{})
 
 	data := []string{"a", "b", "c"}
 
@@ -166,7 +173,7 @@ func TestYAMLPrinter_Print_Slice(t *testing.T) {
 
 func TestYAMLPrinter_Print_Nested(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewYAMLPrinter(&buf)
+	p := NewYAMLPrinter(&buf, &bytes.Buffer{})
 
 	data := map[string]interface{}{
 		"user": map[string]interface{}{
@@ -190,22 +197,28 @@ func TestYAMLPrinter_Print_Nested(t *testing.T) {
 }
 
 func TestYAMLPrinter_PrintError(t *testing.T) {
-	var buf bytes.Buffer
-	p := NewYAMLPrinter(&buf)
+	var buf, errBuf bytes.Buffer
+	p := NewYAMLPrinter(&buf, &errBuf)
 
 	err := errors.New("something went wrong")
-	if printErr := p.PrintError(err); printErr != nil {
-		t.Fatalf("unexpected error: %v", printErr)
+	printErr := p.PrintError(err)
+	var printed *AlreadyPrintedError
+	if !errors.As(printErr, &printed) {
+		t.Fatalf("expected AlreadyPrintedError, got %T", printErr)
 	}
 
-	output := buf.String()
+	// Error goes to errW (stderr), not w (stdout)
+	if buf.Len() > 0 {
+		t.Errorf("expected stdout empty on error, got: %s", buf.String())
+	}
+	output := errBuf.String()
 	if !strings.Contains(output, "error: something went wrong") {
-		t.Errorf("expected error message in output: %s", output)
+		t.Errorf("expected error message on stderr: %s", output)
 	}
 }
 
 func TestYAMLPrinter_ImplementsPrinter(t *testing.T) {
-	var p Printer = NewYAMLPrinter(&bytes.Buffer{})
+	var p Printer = NewYAMLPrinter(&bytes.Buffer{}, &bytes.Buffer{})
 	_ = p // Verify interface compliance
 }
 
@@ -221,7 +234,7 @@ func TestNew_UnknownFormat(t *testing.T) {
 
 func TestJSONPrinter_Print_Map(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewJSONPrinter(&buf)
+	p := NewJSONPrinter(&buf, &bytes.Buffer{})
 
 	data := map[string]interface{}{
 		"name":  "test",
@@ -243,7 +256,7 @@ func TestJSONPrinter_Print_Map(t *testing.T) {
 
 func TestJSONPrinter_Print_Slice(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewJSONPrinter(&buf)
+	p := NewJSONPrinter(&buf, &bytes.Buffer{})
 
 	data := []string{"a", "b", "c"}
 
@@ -259,7 +272,7 @@ func TestJSONPrinter_Print_Slice(t *testing.T) {
 
 func TestJSONPrinter_Print_Nested(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewJSONPrinter(&buf)
+	p := NewJSONPrinter(&buf, &bytes.Buffer{})
 
 	data := map[string]interface{}{
 		"user": map[string]interface{}{
@@ -280,23 +293,29 @@ func TestJSONPrinter_Print_Nested(t *testing.T) {
 }
 
 func TestJSONPrinter_PrintError(t *testing.T) {
-	var buf bytes.Buffer
-	p := NewJSONPrinter(&buf)
+	var buf, errBuf bytes.Buffer
+	p := NewJSONPrinter(&buf, &errBuf)
 
 	err := errors.New("something went wrong")
-	if printErr := p.PrintError(err); printErr != nil {
-		t.Fatalf("unexpected error: %v", printErr)
+	printErr := p.PrintError(err)
+	var printed *AlreadyPrintedError
+	if !errors.As(printErr, &printed) {
+		t.Fatalf("expected AlreadyPrintedError, got %T", printErr)
 	}
 
-	output := buf.String()
+	// Error goes to errW (stderr), not w (stdout)
+	if buf.Len() > 0 {
+		t.Errorf("expected stdout empty on error, got: %s", buf.String())
+	}
+	output := errBuf.String()
 	if !strings.Contains(output, `"error": "something went wrong"`) {
-		t.Errorf("expected error message in output: %s", output)
+		t.Errorf("expected error message on stderr: %s", output)
 	}
 }
 
 func TestJSONPrinter_Indentation(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewJSONPrinter(&buf)
+	p := NewJSONPrinter(&buf, &bytes.Buffer{})
 
 	data := map[string]interface{}{"key": "value"}
 	if err := p.Print(data); err != nil {
@@ -312,7 +331,7 @@ func TestJSONPrinter_Indentation(t *testing.T) {
 
 func TestTextPrinter_Print_Map(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewTextPrinter(&buf)
+	p := NewTextPrinter(&buf, &bytes.Buffer{})
 
 	data := map[string]interface{}{
 		"name":  "test",
@@ -337,7 +356,7 @@ func TestTextPrinter_Print_Map(t *testing.T) {
 
 func TestTextPrinter_Print_Map_SortedKeys(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewTextPrinter(&buf)
+	p := NewTextPrinter(&buf, &bytes.Buffer{})
 
 	data := map[string]interface{}{
 		"zebra": 1,
@@ -362,7 +381,7 @@ func TestTextPrinter_Print_Map_SortedKeys(t *testing.T) {
 
 func TestTextPrinter_Print_Slice(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewTextPrinter(&buf)
+	p := NewTextPrinter(&buf, &bytes.Buffer{})
 
 	data := []interface{}{
 		map[string]interface{}{"id": 1, "name": "first"},
@@ -387,7 +406,7 @@ func TestTextPrinter_Print_Slice(t *testing.T) {
 
 func TestTextPrinter_Print_Table(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewTextPrinter(&buf)
+	p := NewTextPrinter(&buf, &bytes.Buffer{})
 
 	data := []map[string]interface{}{
 		{"id": "1", "name": "Alice"},
@@ -415,7 +434,7 @@ func TestTextPrinter_Print_Table(t *testing.T) {
 
 func TestTextPrinter_Print_EmptyTable(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewTextPrinter(&buf)
+	p := NewTextPrinter(&buf, &bytes.Buffer{})
 
 	data := []map[string]interface{}{}
 
@@ -431,7 +450,7 @@ func TestTextPrinter_Print_EmptyTable(t *testing.T) {
 
 func TestTextPrinter_Print_SimpleValue(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewTextPrinter(&buf)
+	p := NewTextPrinter(&buf, &bytes.Buffer{})
 
 	if err := p.Print("hello world"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -444,23 +463,29 @@ func TestTextPrinter_Print_SimpleValue(t *testing.T) {
 }
 
 func TestTextPrinter_PrintError(t *testing.T) {
-	var buf bytes.Buffer
-	p := NewTextPrinter(&buf)
+	var buf, errBuf bytes.Buffer
+	p := NewTextPrinter(&buf, &errBuf)
 
 	err := errors.New("something went wrong")
-	if printErr := p.PrintError(err); printErr != nil {
-		t.Fatalf("unexpected error: %v", printErr)
+	printErr := p.PrintError(err)
+	var printed *AlreadyPrintedError
+	if !errors.As(printErr, &printed) {
+		t.Fatalf("expected AlreadyPrintedError, got %T", printErr)
 	}
 
-	output := buf.String()
+	// Error goes to errW, not w
+	if buf.Len() > 0 {
+		t.Errorf("expected stdout empty on error, got: %s", buf.String())
+	}
+	output := errBuf.String()
 	if !strings.Contains(output, "Error: something went wrong") {
-		t.Errorf("expected error message in output: %s", output)
+		t.Errorf("expected error message on stderr: %s", output)
 	}
 }
 
 func TestTextPrinter_Print_SliceOfStrings(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewTextPrinter(&buf)
+	p := NewTextPrinter(&buf, &bytes.Buffer{})
 
 	// Test with a simple slice (not interface{})
 	data := []interface{}{"one", "two", "three"}
@@ -477,7 +502,7 @@ func TestTextPrinter_Print_SliceOfStrings(t *testing.T) {
 
 func TestTextPrinter_Print_ReflectSlice(t *testing.T) {
 	var buf bytes.Buffer
-	p := NewTextPrinter(&buf)
+	p := NewTextPrinter(&buf, &bytes.Buffer{})
 
 	// Using a concrete slice type to trigger reflection path
 	type item struct {

--- a/internal/printer/text.go
+++ b/internal/printer/text.go
@@ -11,12 +11,14 @@ import (
 
 // TextPrinter outputs data as human-readable text.
 type TextPrinter struct {
-	w io.Writer
+	w    io.Writer
+	errW io.Writer
 }
 
-// NewTextPrinter creates a new text printer.
-func NewTextPrinter(w io.Writer) *TextPrinter {
-	return &TextPrinter{w: w}
+// NewTextPrinter creates a new text printer with separate output and error
+// writers.
+func NewTextPrinter(w, errW io.Writer) *TextPrinter {
+	return &TextPrinter{w: w, errW: errW}
 }
 
 // Print outputs data as human-readable text.
@@ -40,10 +42,11 @@ func (p *TextPrinter) Print(data interface{}) error {
 	}
 }
 
-// PrintError outputs an error as text.
+// PrintError writes an error to the error writer (stderr) and returns the
+// original error wrapped in AlreadyPrintedError.
 func (p *TextPrinter) PrintError(err error) error {
-	_, writeErr := fmt.Fprintf(p.w, "Error: %s\n", err.Error())
-	return writeErr
+	fmt.Fprintf(p.errW, "Error: %s\n", err.Error())
+	return &AlreadyPrintedError{Err: err}
 }
 
 func (p *TextPrinter) printMap(m map[string]interface{}) error {

--- a/internal/printer/text.go
+++ b/internal/printer/text.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -43,10 +44,15 @@ func (p *TextPrinter) Print(data interface{}) error {
 }
 
 // PrintError writes an error to the error writer (stderr) and returns the
-// original error wrapped in AlreadyPrintedError.
+// original error wrapped in AlreadyPrintedError. Write errors are joined
+// onto the returned chain.
 func (p *TextPrinter) PrintError(err error) error {
-	fmt.Fprintf(p.errW, "Error: %s\n", err.Error())
-	return &AlreadyPrintedError{Err: err}
+	_, writeErr := fmt.Fprintf(p.errW, "Error: %s\n", err.Error())
+	printed := &AlreadyPrintedError{Err: err}
+	if writeErr != nil {
+		return errors.Join(printed, writeErr)
+	}
+	return printed
 }
 
 func (p *TextPrinter) printMap(m map[string]interface{}) error {

--- a/internal/printer/yaml.go
+++ b/internal/printer/yaml.go
@@ -1,6 +1,7 @@
 package printer
 
 import (
+	"errors"
 	"io"
 
 	"gopkg.in/yaml.v3"
@@ -26,12 +27,17 @@ func (p *YAMLPrinter) Print(data interface{}) error {
 }
 
 // PrintError writes a structured error to the error writer (stderr) and
-// returns the original error wrapped in AlreadyPrintedError.
+// returns the original error wrapped in AlreadyPrintedError. Encode errors
+// are joined onto the returned chain.
 func (p *YAMLPrinter) PrintError(err error) error {
 	enc := yaml.NewEncoder(p.errW)
 	enc.SetIndent(2)
-	_ = enc.Encode(map[string]interface{}{
+	encErr := enc.Encode(map[string]interface{}{
 		"error": err.Error(),
 	})
-	return &AlreadyPrintedError{Err: err}
+	printed := &AlreadyPrintedError{Err: err}
+	if encErr != nil {
+		return errors.Join(printed, encErr)
+	}
+	return printed
 }

--- a/internal/printer/yaml.go
+++ b/internal/printer/yaml.go
@@ -8,24 +8,30 @@ import (
 
 // YAMLPrinter outputs data as YAML.
 type YAMLPrinter struct {
-	w io.Writer
+	w    io.Writer
+	errW io.Writer
 }
 
-// NewYAMLPrinter creates a new YAML printer.
-func NewYAMLPrinter(w io.Writer) *YAMLPrinter {
-	return &YAMLPrinter{w: w}
+// NewYAMLPrinter creates a new YAML printer with separate output and error
+// writers.
+func NewYAMLPrinter(w, errW io.Writer) *YAMLPrinter {
+	return &YAMLPrinter{w: w, errW: errW}
 }
 
-// Print outputs data as YAML.
+// Print outputs data as YAML to stdout.
 func (p *YAMLPrinter) Print(data interface{}) error {
 	enc := yaml.NewEncoder(p.w)
 	enc.SetIndent(2)
 	return enc.Encode(data)
 }
 
-// PrintError outputs an error as YAML.
+// PrintError writes a structured error to the error writer (stderr) and
+// returns the original error wrapped in AlreadyPrintedError.
 func (p *YAMLPrinter) PrintError(err error) error {
-	return p.Print(map[string]interface{}{
+	enc := yaml.NewEncoder(p.errW)
+	enc.SetIndent(2)
+	_ = enc.Encode(map[string]interface{}{
 		"error": err.Error(),
 	})
+	return &AlreadyPrintedError{Err: err}
 }

--- a/main.go
+++ b/main.go
@@ -1,13 +1,7 @@
 package main
 
-import (
-	"os"
-
-	"github.com/omriariav/workspace-cli/cmd"
-)
+import "github.com/omriariav/workspace-cli/cmd"
 
 func main() {
-	if err := cmd.Execute(); err != nil {
-		os.Exit(1)
-	}
+	_ = cmd.Execute()
 }


### PR DESCRIPTION
Closes #190, closes #191.

## Summary

Two changes for v1.40.0:

### 1. Non-zero exit codes for API errors (#190)

| Exit code | Meaning |
|---|---|
| 0 | Success |
| 1 | Generic API / runtime error |
| 2 | CLI usage error (wrong args, unknown flag) |
| 3 | Auth failure (HTTP 401 / 403) |
| 4 | Transient / retryable (HTTP 429, 5xx) |

- `PrintError` now writes structured `{"error":"..."}` JSON to **stderr** (not stdout). Stdout is reserved for successful responses.
- `Execute()` inspects `googleapi.Error.Code` to pick the exit code.
- Cobra validation errors (wrong args, unknown flags) exit 2 with a plain-text error on stderr; usage text still prints.
- `--quiet` suppresses output but preserves exit codes.

### 2. People API scope fix (#191)

`gws people get people/me` returned 403 because `--services people` didn't include `userinfo.profile`. Fixed by adding it to the `people` service scope set. Also removed `admin.directory.group.*` scopes from `people` (those belong to `groups`).

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run ./...` — clean
- [x] Exit code mapping tests: generic, 401, 403, 429, 500, 503, 404, wrapped errors
- [x] Printer tests updated: constructors take `(w, errW)`, `PrintError` returns `AlreadyPrintedError`, error output verified on errW
- [x] All error-path tests across chat, slides, forms, contacts, sheets switched from stdout to stderr capture
- [ ] Live verification: `gws people get people/me --raw` returns 200 after `gws auth login --services people`
- [ ] Live verification: `gws gmail thread nonexistent --raw; echo $?` exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)