### PR TITLE
[codex] Update Codex skills

### DIFF
--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -230,6 +230,87 @@ var expectedSkills = []string{
 	"contacts", "groups", "keep",
 }
 
+func TestCodexSkills_MirrorClaudeSkills(t *testing.T) {
+	claudeBase := skillsDir(t)
+	codexBase := codexSkillsDir(t)
+
+	for _, skill := range expectedSkills {
+		t.Run(skill, func(t *testing.T) {
+			claudeSkillDir := filepath.Join(claudeBase, skill)
+			codexSkillDir := filepath.Join(codexBase, skill)
+
+			claudeData, err := os.ReadFile(filepath.Join(claudeSkillDir, "SKILL.md"))
+			if err != nil {
+				t.Fatalf("failed to read Claude SKILL.md: %v", err)
+			}
+			codexData, err := os.ReadFile(filepath.Join(codexSkillDir, "SKILL.md"))
+			if err != nil {
+				t.Fatalf("failed to read Codex SKILL.md: %v", err)
+			}
+
+			want := stripTopLevelSkillVersion(string(claudeData))
+			if got := string(codexData); got != want {
+				t.Error("Codex SKILL.md should mirror Claude SKILL.md except for the top-level version field")
+			}
+
+			assertCodexBundledFilesMirrorClaude(t, claudeSkillDir, codexSkillDir)
+		})
+	}
+}
+
+func stripTopLevelSkillVersion(content string) string {
+	lines := strings.SplitAfter(content, "\n")
+	for i, line := range lines {
+		if i > 0 && line == "---\n" {
+			return content
+		}
+		if strings.HasPrefix(line, "version: ") {
+			return strings.Join(append(lines[:i], lines[i+1:]...), "")
+		}
+	}
+	return content
+}
+
+func assertCodexBundledFilesMirrorClaude(t *testing.T, claudeSkillDir, codexSkillDir string) {
+	t.Helper()
+
+	err := filepath.Walk(claudeSkillDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+
+		rel, err := filepath.Rel(claudeSkillDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "SKILL.md" {
+			return nil
+		}
+
+		assertFilesEqual(t, path, filepath.Join(codexSkillDir, rel))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk %s: %v", claudeSkillDir, err)
+	}
+}
+
+func assertFilesEqual(t *testing.T, wantPath, gotPath string) {
+	t.Helper()
+
+	want, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", wantPath, err)
+	}
+	got, err := os.ReadFile(gotPath)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", gotPath, err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("expected %s to mirror %s", gotPath, wantPath)
+	}
+}
+
 func TestSkillDirectories_AllExist(t *testing.T) {
 	base := skillsDir(t)
 	for _, skill := range expectedSkills {

--- a/plugins/gws/.codex-plugin/plugin.json
+++ b/plugins/gws/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gws",
-  "version": "1.35.0",
+  "version": "1.40.0",
   "description": "Unofficial Google Workspace CLI skills for Codex. Teaches Codex how to use gws for Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, Chat, Forms, Contacts, Groups, Keep, and Search.",
   "author": {
     "name": "Omri Ariav",

--- a/plugins/gws/skills/chat/SKILL.md
+++ b/plugins/gws/skills/chat/SKILL.md
@@ -56,6 +56,8 @@ For initial setup, see the `gws-auth` skill.
 | Read recent messages | `gws chat messages <space-id> --order-by "createTime DESC" --max 10` |
 | Messages after a date | `gws chat messages <space-id> --after "2026-02-17T00:00:00Z"` |
 | Messages in a range | `gws chat messages <space-id> --after "2026-02-17T00:00:00Z" --before "2026-02-20T00:00:00Z"` |
+| Recap recent messages | `gws chat recent --since 2h` |
+| Recap last 7 days | `gws chat recent --since 7d --max 1000` |
 | Send a message | `gws chat send --space <space-id> --text "Hello"` |
 | Get a single message | `gws chat get <message-name>` |
 | Update a message | `gws chat update <message-name> --text "New text"` |
@@ -113,6 +115,53 @@ gws chat messages <space-id> [flags]
 - `--resolve-senders` — Make extra API calls to fill missing `sender_display_name` (via space membership listing) and add a `self` boolean (via People API `people/me`). One extra Chat call per space plus one People call per invocation.
 
 `--after` and `--before` are convenience shortcuts for `--filter`. They combine with `--filter` using AND.
+
+### recent — Recap recent messages across active spaces
+
+```bash
+gws chat recent --since <window> [flags]
+```
+
+Recaps Chat messages across every space active within `--since`, without iterating message history for inactive spaces. Uses `spaces.list` `lastActiveTime` as the cheap prefilter, then queries `spaces.messages.list` per active space with `createTime > since` and `orderBy=createTime DESC`. Results are flattened and sorted globally by newest first. Includes both sent and received messages by default.
+
+**Flags:**
+- `--since string` — Time window: a Go duration (`2h`, `12h`, `7d`) or RFC3339 timestamp (`2026-04-30T09:00:00Z`). Default `2h`.
+- `--max int` — Total message cap (default 500, `0` = all)
+- `--max-per-space int` — Per-space cap (default 100, `0` = all)
+- `--max-spaces int` — Active-space cap after sorting by `lastActiveTime` DESC (default `0` = all)
+- `--resolve-senders` — Fill `sender_display_name` (one extra membership-list call per active space) and add `self` via People API
+- `--exclude-self` — Omit messages sent by the authenticated user (best-effort self detection via People API)
+
+**Output:**
+```json
+{
+  "since": "2026-04-30T09:00:00Z",
+  "spaces_scanned": 123,
+  "active_spaces": 8,
+  "count": 42,
+  "messages": [
+    {
+      "space": "spaces/AAAA",
+      "space_display_name": "Team Chat",
+      "space_type": "SPACE",
+      "space_last_active_time": "2026-04-30T10:58:00Z",
+      "name": "spaces/AAAA/messages/msg1",
+      "text": "...",
+      "create_time": "2026-04-30T10:57:00Z",
+      "sender": "Alice",
+      "sender_resource": "users/123"
+    }
+  ]
+}
+```
+
+**Examples:**
+```bash
+gws chat recent --since 2h
+gws chat recent --since 12h --resolve-senders --exclude-self
+gws chat recent --since 7d --max 1000 --max-per-space 200
+gws chat recent --since 2026-04-30T09:00:00Z
+```
 
 Sender attribution fields:
 - `sender` — existing display-name-or-resource string. Always present when the message has a sender.

--- a/plugins/gws/skills/chat/references/commands.md
+++ b/plugins/gws/skills/chat/references/commands.md
@@ -34,13 +34,29 @@ Usage: gws chat list [flags]
 |------|------|---------|-------------|
 | `--filter` | string | | Filter spaces (e.g. `spaceType = "SPACE"`) |
 | `--page-size` | int | 100 | Number of spaces per page |
+| `--all` | bool | false | Fetch every page (raw mode aggregates the list field and drops `nextPageToken`) |
+| `--raw` | bool | false | Emit unmodified `spaces.list` response JSON |
+| `--params` | string | | JSON object mapped to `spaces.list` request parameters (`pageSize`, `filter`, `pageToken`). Overrides equivalent CLI flags. |
 
 ### Output Fields (JSON)
 
-Each space includes:
+Default ergonomic output. Each space includes:
 - `name` — Space resource name (e.g., `spaces/AAAA1234`)
 - `displayName` — Human-readable space name
 - `type` — Space type (`ROOM`, `DM`, `GROUP_CHAT`)
+
+Under `--raw` the response shape matches Google's `spaces.list` reference exactly (`{"spaces":[...],"nextPageToken":"..."}`).
+
+---
+
+## gws chat spaces list
+
+Programmatic alias for `gws chat list` that mirrors the API method name. Same flag surface; useful when scripting against `spaces.list`.
+
+```
+Usage: gws chat spaces list [flags]
+gws chat spaces list --params '{"pageSize":50,"filter":"spaceType = \"DIRECT_MESSAGE\""}' --raw --all
+```
 
 ---
 
@@ -49,7 +65,7 @@ Each space includes:
 Lists recent messages in a Chat space. Supports filtering, ordering, pagination, and showing deleted messages.
 
 ```
-Usage: gws chat messages <space-id> [flags]
+Usage: gws chat messages [space-id] [flags]
 ```
 
 | Flag | Type | Default | Description |
@@ -61,6 +77,17 @@ Usage: gws chat messages <space-id> [flags]
 | `--order-by` | string | | Order messages (e.g. `createTime DESC`) |
 | `--show-deleted` | bool | false | Include deleted messages in results |
 | `--resolve-senders` | bool | false | Make extra API calls to fill missing `sender_display_name` (via space membership listing) and add `self` (via People API `people/me`). |
+| `--all` | bool | false | Fetch every page (raw mode aggregates the `messages` field; ignores `--max`) |
+| `--raw` | bool | false | Emit unmodified `spaces.messages.list` response JSON |
+| `--params` | string | | JSON object mapped to `spaces.messages.list` request parameters (`parent`, `pageSize`, `filter`, `orderBy`, `showDeleted`, `pageToken`). Overrides equivalent CLI flags. |
+
+### gws chat messages list
+
+Programmatic alias that accepts `parent` via `--params` instead of a positional argument:
+
+```
+gws chat messages list --params '{"parent":"spaces/AAA","pageSize":50,"filter":"createTime > \"2025-01-01T00:00:00Z\""}' --raw --all
+```
 
 `--after` and `--before` are convenience flags that translate to filter expressions. They combine with `--filter` using AND.
 
@@ -79,7 +106,7 @@ The space ID format is `spaces/AAAA1234` (get from `gws chat list`).
 Lists all members of a Chat space with display names and emails (auto-resolved via People API, cached locally).
 
 ```
-Usage: gws chat members <space-id> [flags]
+Usage: gws chat members [space-id] [flags]
 ```
 
 | Flag | Type | Default | Description |
@@ -88,6 +115,44 @@ Usage: gws chat members <space-id> [flags]
 | `--filter` | string | | Filter members (e.g. `member.type = "HUMAN"`) |
 | `--show-groups` | bool | false | Include Google Group memberships |
 | `--show-invited` | bool | false | Include invited memberships |
+| `--all` | bool | false | Fetch every page (raw mode aggregates the `memberships` field; ignores `--max`) |
+| `--raw` | bool | false | Emit unmodified `spaces.members.list` response JSON |
+| `--params` | string | | JSON object mapped to `spaces.members.list` request parameters (`parent`, `pageSize`, `filter`, `showGroups`, `showInvited`, `pageToken`). Overrides equivalent CLI flags. |
+
+### gws chat members list
+
+Programmatic alias that accepts `parent` via `--params` instead of a positional argument:
+
+```
+gws chat members list --params '{"parent":"spaces/AAA","pageSize":50}' --raw --all
+```
+
+---
+
+## gws chat recent
+
+Recaps Chat messages across every space active within a time window. Uses `spaces.list` `lastActiveTime` as a prefilter, then queries `spaces.messages.list` per active space with `createTime > since` and `orderBy=createTime DESC`. Output is flattened and globally sorted newest-first.
+
+```
+Usage: gws chat recent [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--since` | string | `2h` | Time window: Go duration (`2h`, `12h`, `7d`) or RFC3339 timestamp |
+| `--max` | int | 500 | Maximum total messages (0 = all) |
+| `--max-per-space` | int | 100 | Maximum messages per active space (0 = all) |
+| `--max-spaces` | int | 0 | Cap on active spaces after sorting by `lastActiveTime` DESC (0 = all) |
+| `--resolve-senders` | bool | false | Resolve sender display names (one extra membership-list call per active space) and detect `self` |
+| `--exclude-self` | bool | false | Omit authenticated-user messages (best-effort, requires self detection) |
+
+### Output Fields (JSON)
+
+- `since` — Resolved RFC3339 cutoff
+- `spaces_scanned` — Total spaces returned by `spaces.list`
+- `active_spaces` — Spaces matching `lastActiveTime >= since` (after `--max-spaces` cap)
+- `count` — Number of messages in the response (after `--max` cap)
+- `messages[]` — Each entry: `space`, `space_display_name`, `space_type`, `space_last_active_time`, `name`, `text`, `create_time`, `sender`, plus `sender_type`/`sender_resource`/`sender_display_name`/`self` when available
 
 ---
 

--- a/plugins/gws/skills/contacts/references/commands.md
+++ b/plugins/gws/skills/contacts/references/commands.md
@@ -131,23 +131,48 @@ gws contacts search "Jane Smith" --format json | jq -r '.contacts[0].resource_na
 Gets detailed information about a specific contact by resource name.
 
 ```
-Usage: gws contacts get <resource-name>
+Usage: gws contacts get [resource-name] [flags]
 ```
 
 | Argument | Type | Required | Description |
 |----------|------|----------|-------------|
-| `resource-name` | string | Yes | Resource identifier (e.g., `people/c1234567890`) |
+| `resource-name` | string | One of | Resource identifier (e.g., `people/c1234567890`). Required unless supplied via `--params resourceName`. |
 
-No additional flags.
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--raw` | bool | false | Emit unmodified `people.get` response JSON |
+| `--params` | string | | JSON object mapped to `people.get` request parameters (`resourceName`, `personFields`, `sources`). Overrides equivalent CLI flags. |
 
 ### Output Fields (JSON)
 
-Returns a single contact object with:
+Default ergonomic output is a single contact object with:
 - `resource_name` — Resource identifier
 - `name` — Contact's display name
 - `emails` — Array of email addresses (if available)
 - `phones` — Array of phone numbers (if available)
 - `organization` — Object with `name` and `title` (if available)
+
+Under `--raw` the response shape matches Google's `people.get` reference exactly (`resourceName`, `etag`, `names[]`, `emailAddresses[]`, etc.).
+
+---
+
+## gws people get
+
+Programmatic People.Get wrapper. Designed for scripting; pass `resourceName` and `personFields` directly as the API expects.
+
+```
+Usage: gws people get [resource-name] [flags]
+```
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--person-fields` | string | (legacy default) | Comma-separated personFields mask (overridden by `--params personFields`) |
+| `--raw` | bool | false | Emit unmodified `people.get` response JSON |
+| `--params` | string | | JSON object mapped to `people.get` request parameters (`resourceName`, `personFields`, `sources`, `requestMask.includeField`). Overrides equivalent CLI flags. |
+
+```
+gws people get --params '{"resourceName":"people/me","personFields":"emailAddresses"}' --raw
+```
 
 ### Resource Name Format
 

--- a/plugins/gws/skills/drive/SKILL.md
+++ b/plugins/gws/skills/drive/SKILL.md
@@ -338,14 +338,23 @@ gws drive delete-comment --file-id <id> --comment-id <cid>
 
 ### resolve-comment — Resolve a comment
 
+Posts a reply with `action=resolve` (the documented Drive API path for state
+transitions). The original comment content is never modified. Pass an
+optional `--content` to attach a closing note.
+
 ```bash
 gws drive resolve-comment --file-id <id> --comment-id <cid>
+gws drive resolve-comment --file-id <id> --comment-id <cid> --content "fixed in #1234"
 ```
 
-### unresolve-comment — Unresolve a comment
+### unresolve-comment — Reopen a resolved comment
+
+Posts a reply with `action=reopen`. The original comment content is never
+modified. Pass an optional `--content` to attach a reopening note.
 
 ```bash
 gws drive unresolve-comment --file-id <id> --comment-id <cid>
+gws drive unresolve-comment --file-id <id> --comment-id <cid> --content "still broken on safari"
 ```
 
 ### replies — List replies

--- a/plugins/gws/skills/drive/references/commands.md
+++ b/plugins/gws/skills/drive/references/commands.md
@@ -409,7 +409,8 @@ Usage: gws drive delete-comment [flags]
 
 ## gws drive resolve-comment
 
-Marks a comment as resolved.
+Marks a comment as resolved by posting a reply with `action=resolve`. The
+original comment content is preserved.
 
 ```
 Usage: gws drive resolve-comment [flags]
@@ -419,12 +420,14 @@ Usage: gws drive resolve-comment [flags]
 |------|------|---------|----------|-------------|
 | `--file-id` | string | | Yes | File ID |
 | `--comment-id` | string | | Yes | Comment ID |
+| `--content` | string | | No | Optional closing note attached to the resolve reply |
 
 ---
 
 ## gws drive unresolve-comment
 
-Marks a comment as unresolved.
+Reopens a resolved comment by posting a reply with `action=reopen`. The
+original comment content is preserved.
 
 ```
 Usage: gws drive unresolve-comment [flags]
@@ -434,6 +437,7 @@ Usage: gws drive unresolve-comment [flags]
 |------|------|---------|----------|-------------|
 | `--file-id` | string | | Yes | File ID |
 | `--comment-id` | string | | Yes | Comment ID |
+| `--content` | string | | No | Optional reopening note attached to the reopen reply |
 
 ---
 

--- a/plugins/gws/skills/gmail/SKILL.md
+++ b/plugins/gws/skills/gmail/SKILL.md
@@ -103,7 +103,7 @@ gws gmail list --query "label:work" --all
 gws gmail thread <thread-id>
 ```
 
-Reads and displays all messages in a Gmail thread (conversation). Use the `thread_id` from `gws gmail list` output. Returns all messages with headers, body, and labels.
+Reads and displays all messages in a Gmail thread (conversation). Use the `thread_id` from `gws gmail list` output. Returns all messages with headers, body, labels, and `attachments` (when present) — each entry exposes `filename`, `mime_type`, `size`, `attachment_id`, and `part_id`.
 
 ### read — Read a message
 
@@ -111,7 +111,12 @@ Reads and displays all messages in a Gmail thread (conversation). Use the `threa
 gws gmail read <message-id>
 ```
 
-Reads and displays the content of a specific email message. Use the `message_id` from `gws gmail list` output.
+Reads and displays the content of a specific email message. Use the `message_id` from `gws gmail list` output. When the message has attachments, the response includes an `attachments` array. Each entry has `filename`, `mime_type`, `size`, `attachment_id`, and `part_id`; pass `attachment_id` to `gws gmail attachment --id <id>` to download.
+
+```bash
+ATT_ID=$(gws gmail read <msg-id> --format json | jq -r '.attachments[0].attachment_id')
+gws gmail attachment --message-id <msg-id> --id "$ATT_ID" --output file.pdf
+```
 
 ### send — Send an email
 
@@ -454,9 +459,15 @@ gws gmail attachment --message-id <msg-id> --id <attachment-id> --output <file-p
 - `--id string` — Attachment ID (required)
 - `--output string` — Output file path (required)
 
+Discover the `--id` value from the `attachments` array on `gws gmail read` or `gws gmail thread` output. Each entry includes `filename`, `mime_type`, `size`, `attachment_id`, and `part_id`.
+
 **Examples:**
 ```bash
 gws gmail attachment --message-id 18abc123 --id ANGjdJ9x --output report.pdf
+
+# End-to-end: discover the attachment ID and download it.
+ATT_ID=$(gws gmail read 18abc123 --format json | jq -r '.attachments[0].attachment_id')
+gws gmail attachment --message-id 18abc123 --id "$ATT_ID" --output report.pdf
 ```
 
 ## Tips for AI Agents

--- a/plugins/gws/skills/gmail/references/commands.md
+++ b/plugins/gws/skills/gmail/references/commands.md
@@ -30,6 +30,8 @@ Usage: gws gmail list [flags]
 | `--all` | bool | false | Fetch all matching results (may take time for large result sets) |
 | `--query` | string | | Gmail search query |
 | `--include-labels` | bool | false | Include Gmail label IDs in output |
+| `--raw` | bool | false | Emit unmodified `users.messages.list` response JSON (switches the underlying call from `threads.list` to `messages.list`) |
+| `--params` | string | | JSON object mapped to `users.messages.list` request parameters (`q`, `maxResults` [per-page], `pageToken`, `includeSpamTrash`, `labelIds`). Overrides equivalent CLI flags. |
 
 ### Output Fields (JSON)
 
@@ -80,6 +82,12 @@ No additional flags. Use the `message_id` from `gws gmail list` output.
 - `headers` — Object with `subject`, `from`, `to`, `date`, `cc`, `bcc`
 - `body` — Message body text
 - `labels` — Applied label IDs
+- `attachments` — Array (omitted when empty). Each entry:
+  - `filename` — Attachment file name
+  - `mime_type` — MIME type
+  - `size` — Size in bytes
+  - `attachment_id` — Pass to `gws gmail attachment --id <id>`
+  - `part_id` — Gmail part identifier
 
 ---
 
@@ -88,13 +96,19 @@ No additional flags. Use the `message_id` from `gws gmail list` output.
 Reads and displays all messages in a Gmail thread (conversation).
 
 ```
-Usage: gws gmail thread <thread-id>
+Usage: gws gmail thread [thread-id]
 ```
 
-No additional flags. Use the `thread_id` from `gws gmail list` output.
+Use the `thread_id` from `gws gmail list` output.
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--raw` | bool | false | Emit unmodified `users.threads.get` response JSON (full payload tree, base64 `parts[*].body.data`, `headers` as `{name,value}` arrays, `internalDate`, `labelIds`, `snippet`) |
+| `--params` | string | | JSON object mapped to `users.threads.get` request parameters (`id`, `format`, `metadataHeaders`). Overrides equivalent CLI flags. |
 
 ### Output Fields (JSON)
 
+Default ergonomic output:
 - `thread_id` — Thread ID
 - `message_count` — Number of messages in thread
 - `messages` — Array of messages, each with:
@@ -102,6 +116,9 @@ No additional flags. Use the `thread_id` from `gws gmail list` output.
   - `headers` — Object with `subject`, `from`, `to`, `date`, `cc`, `bcc`
   - `body` — Message body text
   - `labels` — Applied label IDs
+  - `attachments` — Array (omitted when empty); same shape as `gws gmail read`
+
+Under `--raw` the response shape matches Google's `users.threads.get` reference exactly.
 
 ---
 
@@ -580,7 +597,7 @@ Usage: gws gmail attachment [flags]
 | Flag | Type | Default | Required | Description |
 |------|------|---------|----------|-------------|
 | `--message-id` | string | | Yes | Message ID |
-| `--id` | string | | Yes | Attachment ID |
+| `--id` | string | | Yes | Attachment ID (from the `attachments` array on `gws gmail read` / `gws gmail thread`) |
 | `--output` | string | | Yes | Output file path |
 
 ### Output Fields (JSON)

--- a/plugins/gws/skills/slides/LEARNINGS.md
+++ b/plugins/gws/skills/slides/LEARNINGS.md
@@ -1,0 +1,28 @@
+# gws slides - Learnings
+
+Session-specific learnings and gotchas discovered during real usage of the gws slides skill.
+
+> **Note**: This file is a template. Add your own learnings as you use the skill.
+
+---
+
+## Template Entry
+
+**Context**: [What you were building]
+
+### What Worked
+
+1. [Command that worked well]
+   ```bash
+   gws slides <command>
+   ```
+
+### What Failed
+
+1. [Issue encountered]
+   - **Root cause**: [Why it failed]
+   - **Workaround**: [How you solved it]
+
+### Tags
+
+`[tag1]` `[tag2]`

--- a/plugins/gws/skills/slides/SKILL.md
+++ b/plugins/gws/skills/slides/SKILL.md
@@ -533,3 +533,9 @@ SLIDE_ID=$(gws slides list "<PRES_ID>" | jq -r '.slides[2].id')
 # Move to high position (API adjusts to valid range)
 gws slides reorder-slides "<PRES_ID>" --slide-ids "$SLIDE_ID" --to 99
 ```
+
+## Learnings
+
+See [LEARNINGS.md](./LEARNINGS.md) for session-specific learnings and gotchas discovered during real usage.
+
+> **Note**: LEARNINGS.md is a template. Keep sensitive/proprietary learnings local - don't commit them to the repo.


### PR DESCRIPTION
## Summary
- sync the Codex gws skill docs with the Claude skill docs while preserving Codex frontmatter requirements
- add a regression test so Codex skill docs and bundled files keep mirroring the Claude skill tree
- bump the Codex plugin manifest to 1.40.0 and include the Slides learnings file in the Codex plugin bundle

## Validation
- make test
- python3 /Users/omri.a/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py /Users/omri.a/Code/workspace-cli/plugins/gws