### PR TITLE
feat: gws gmail links — HTML anchor extraction (issue #200)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 | Service | Commands |
 |---------|----------|
 | `auth` | login, logout, status |
-| `gmail` | list, read, thread, send, reply, forward, labels, label, archive, trash, event-id, untrash, delete, batch-modify, batch-delete, trash-thread, untrash-thread, delete-thread, label-info, create-label, update-label, delete-label, drafts, draft, create-draft, update-draft, send-draft, delete-draft, attachment |
+| `gmail` | list, read, links, thread, send, reply, forward, labels, label, archive, trash, event-id, untrash, delete, batch-modify, batch-delete, trash-thread, untrash-thread, delete-thread, label-info, create-label, update-label, delete-label, drafts, draft, create-draft, update-draft, send-draft, delete-draft, attachment |
 | `calendar` | list, events, create, update, delete, rsvp, get, quick-add, instances, move, get-calendar, create-calendar, update-calendar, delete-calendar, clear, subscribe, unsubscribe, calendar-info, update-subscription, acl, share, unshare, update-acl, freebusy, colors, settings |
 | `tasks` | lists, list, list-info, create, create-list, update, update-list, delete-list, get, delete, complete, move, clear |
 | `drive` | list, search, info, download, upload, create-folder, move, delete, copy, convert, comments, permissions, share, unshare, permission, update-permission, revisions, revision, delete-revision, replies, reply, get-reply, delete-reply, comment, add-comment, delete-comment, resolve-comment, unresolve-comment, export, empty-trash, update, shared-drives, shared-drive, create-drive, delete-drive, update-drive, about, changes, activity |
@@ -50,7 +50,7 @@ go run ./cmd/gws    # or go run .
 
 ## Current Version
 
-**v1.40.0** - Non-zero exit codes: 0=success, 1=generic API/runtime, 2=CLI usage / runtime input-validation, 3=auth (401/403), 4=transient (429/5xx). CLI usage errors (Cobra-level: wrong args, unknown flags) and runtime input-validation (required-flag checks, mutually-exclusive flags, out-of-range/enum values, malformed `--params`) exit 2 with plain text on stderr. Server/file state errors (no cache found, document empty, resource not found, "not an attendee") and wrapped API errors exit 1/3/4 with a structured error on stderr; the format follows `--format` (JSON by default, `yaml` or `text` if set). Stdout is reserved for successful responses. See `cmd/usage.go` for the convention new commands should follow. `--services people` scope fix: adds `userinfo.profile` so `gws people get people/me` works without a 403.
+**v1.40.1** - Gmail HTML link extraction via `gws gmail links <message-id>`, including read-only `text/html` MIME traversal, attachment-backed HTML bodies, deterministic JSON link output, and Google Docs metadata parsing.
 
 ## Roadmap
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG := ./cmd/gws
 BUILD_DIR := ./bin
 
 # Version info
-VERSION ?= 1.40.0
+VERSION ?= 1.40.1
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/omriariav/workspace-cli/cmd.Version=$(VERSION) \

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Add `--format text` for human-readable output, or `--format yaml` for YAML.
 | `gws gmail send-draft <id>` | Send an existing draft |
 | `gws gmail delete-draft <id>` | Delete a draft |
 | `gws gmail attachment` | Download attachment (`--message-id`, `--id`, `--output`) |
+| `gws gmail links <id>` | Extract HTML anchor links from a message |
 
 ### Calendar
 

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -146,6 +146,7 @@ func TestGmailCommands(t *testing.T) {
 		{"send-draft", "send-draft", false},
 		{"delete-draft", "delete-draft", false},
 		{"attachment", "attachment", false},
+		{"links", "links <message-id>", true},
 	}
 
 	for _, tt := range tests {

--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -2626,8 +2626,9 @@ func collectHTMLParts(part *gmail.MessagePart, out *[]string) {
 	}
 	if part.MimeType == "text/html" {
 		if part.Body != nil && part.Body.Data != "" {
-			data, err := base64.URLEncoding.DecodeString(part.Body.Data)
-			if err == nil {
+			if data, err := base64.RawURLEncoding.DecodeString(part.Body.Data); err == nil {
+				*out = append(*out, string(data))
+			} else if data, err := base64.URLEncoding.DecodeString(part.Body.Data); err == nil {
 				*out = append(*out, string(data))
 			}
 		}
@@ -2657,7 +2658,7 @@ func parseHTMLAnchors(htmlBody string) []map[string]interface{} {
 					break
 				}
 			}
-			if href != "" && !strings.HasPrefix(href, "mailto:") {
+			if href != "" {
 				text := strings.TrimSpace(htmlNodeText(n))
 				link := map[string]interface{}{
 					"text":      text,

--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -2697,7 +2697,7 @@ func htmlNodeText(n *html.Node) string {
 // query, and tab_id. Returns nil for non-Docs URLs.
 func parseGoogleDocsURL(href string) map[string]interface{} {
 	u, err := url.Parse(href)
-	if err != nil || u.Host != "docs.google.com" {
+	if err != nil || !strings.EqualFold(u.Hostname(), "docs.google.com") {
 		return nil
 	}
 	// Expect path: /document/d/{docId}/...

--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/omriariav/workspace-cli/internal/client"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/html"
 	"google.golang.org/api/gmail/v1"
 )
 
@@ -312,6 +313,14 @@ var gmailAttachmentCmd = &cobra.Command{
 	RunE:  runGmailAttachment,
 }
 
+var gmailLinksCmd = &cobra.Command{
+	Use:   "links <message-id>",
+	Short: "Extract HTML anchor links from a Gmail message",
+	Long:  "Fetches the full message and extracts <a href> anchors from text/html MIME parts. Includes parsed Google Docs metadata where applicable.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runGmailLinks,
+}
+
 func init() {
 	rootCmd.AddCommand(gmailCmd)
 	gmailCmd.AddCommand(gmailListCmd)
@@ -385,6 +394,7 @@ func init() {
 	gmailCmd.AddCommand(gmailSendDraftCmd)
 	gmailCmd.AddCommand(gmailDeleteDraftCmd)
 	gmailCmd.AddCommand(gmailAttachmentCmd)
+	gmailCmd.AddCommand(gmailLinksCmd)
 
 	// Batch modify flags
 	gmailBatchModifyCmd.Flags().String("ids", "", "Comma-separated message IDs (required)")
@@ -2564,4 +2574,147 @@ func runGmailAttachment(cmd *cobra.Command, args []string) error {
 		"file":   output,
 		"size":   len(data),
 	})
+}
+
+func runGmailLinks(cmd *cobra.Command, args []string) error {
+	p := GetPrinter()
+	ctx := context.Background()
+
+	factory, err := client.NewFactory(ctx)
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	svc, err := factory.Gmail()
+	if err != nil {
+		return p.PrintError(err)
+	}
+
+	messageID := args[0]
+
+	msg, err := svc.Users.Messages.Get("me", messageID).Format("full").Do()
+	if err != nil {
+		return p.PrintError(fmt.Errorf("failed to get message: %w", err))
+	}
+
+	links := extractHTMLLinks(msg.Payload)
+
+	return p.Print(map[string]interface{}{
+		"message_id": msg.Id,
+		"links":      links,
+	})
+}
+
+// extractHTMLLinks walks the MIME tree and returns all <a href> anchors found
+// in text/html parts.
+func extractHTMLLinks(payload *gmail.MessagePart) []map[string]interface{} {
+	var htmlBodies []string
+	collectHTMLParts(payload, &htmlBodies)
+
+	links := []map[string]interface{}{}
+	for _, body := range htmlBodies {
+		links = append(links, parseHTMLAnchors(body)...)
+	}
+	return links
+}
+
+// collectHTMLParts recursively collects decoded text/html body strings from a
+// MIME part tree.
+func collectHTMLParts(part *gmail.MessagePart, out *[]string) {
+	if part == nil {
+		return
+	}
+	if part.MimeType == "text/html" {
+		if part.Body != nil && part.Body.Data != "" {
+			data, err := base64.URLEncoding.DecodeString(part.Body.Data)
+			if err == nil {
+				*out = append(*out, string(data))
+			}
+		}
+		return
+	}
+	for _, child := range part.Parts {
+		collectHTMLParts(child, out)
+	}
+}
+
+// parseHTMLAnchors extracts <a href> anchors from an HTML string and returns
+// structured link records in document order.
+func parseHTMLAnchors(htmlBody string) []map[string]interface{} {
+	doc, err := html.Parse(strings.NewReader(htmlBody))
+	if err != nil {
+		return nil
+	}
+
+	var links []map[string]interface{}
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			var href string
+			for _, attr := range n.Attr {
+				if attr.Key == "href" {
+					href = attr.Val
+					break
+				}
+			}
+			if href != "" && !strings.HasPrefix(href, "mailto:") {
+				text := strings.TrimSpace(htmlNodeText(n))
+				link := map[string]interface{}{
+					"text":      text,
+					"href":      href,
+					"mime_part": "text/html",
+				}
+				if meta := parseGoogleDocsURL(href); meta != nil {
+					for k, v := range meta {
+						link[k] = v
+					}
+				}
+				links = append(links, link)
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+	return links
+}
+
+// htmlNodeText returns the concatenated visible text of a node subtree.
+func htmlNodeText(n *html.Node) string {
+	if n.Type == html.TextNode {
+		return n.Data
+	}
+	var sb strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		sb.WriteString(htmlNodeText(c))
+	}
+	return sb.String()
+}
+
+// parseGoogleDocsURL parses a Google Docs URL and returns doc id, fragment,
+// query, and tab_id. Returns nil for non-Docs URLs.
+func parseGoogleDocsURL(href string) map[string]interface{} {
+	u, err := url.Parse(href)
+	if err != nil || u.Host != "docs.google.com" {
+		return nil
+	}
+	// Expect path: /document/d/{docId}/...
+	segments := strings.Split(strings.TrimPrefix(u.Path, "/"), "/")
+	if len(segments) < 3 || segments[0] != "document" || segments[1] != "d" || segments[2] == "" {
+		return nil
+	}
+	result := map[string]interface{}{
+		"google_docs_id": segments[2],
+	}
+	if u.Fragment != "" {
+		result["fragment"] = "#" + u.Fragment
+	}
+	if u.RawQuery != "" {
+		result["query"] = u.RawQuery
+	}
+	if tab := u.Query().Get("tab"); tab != "" {
+		result["tab_id"] = tab
+	}
+	return result
 }

--- a/cmd/gmail.go
+++ b/cmd/gmail.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/omriariav/workspace-cli/internal/client"
+	"github.com/omriariav/workspace-cli/internal/printer"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/html"
 	"google.golang.org/api/gmail/v1"
@@ -2590,14 +2591,23 @@ func runGmailLinks(cmd *cobra.Command, args []string) error {
 		return p.PrintError(err)
 	}
 
-	messageID := args[0]
+	return runGmailLinksWithService(svc, args[0], p)
+}
 
+func runGmailLinksWithService(svc *gmail.Service, messageID string, p printer.Printer) error {
 	msg, err := svc.Users.Messages.Get("me", messageID).Format("full").Do()
 	if err != nil {
 		return p.PrintError(fmt.Errorf("failed to get message: %w", err))
 	}
 
-	links := extractHTMLLinks(msg.Payload)
+	attachmentMessageID := msg.Id
+	if attachmentMessageID == "" {
+		attachmentMessageID = messageID
+	}
+	links, err := extractHTMLLinks(svc, attachmentMessageID, msg.Payload)
+	if err != nil {
+		return p.PrintError(err)
+	}
 
 	return p.Print(map[string]interface{}{
 		"message_id": msg.Id,
@@ -2606,37 +2616,72 @@ func runGmailLinks(cmd *cobra.Command, args []string) error {
 }
 
 // extractHTMLLinks walks the MIME tree and returns all <a href> anchors found
-// in text/html parts.
-func extractHTMLLinks(payload *gmail.MessagePart) []map[string]interface{} {
+// in text/html parts. svc and messageID are used to fetch body data stored as
+// Gmail attachments (Body.AttachmentId); pass nil/empty to skip attachment fetch.
+func extractHTMLLinks(svc *gmail.Service, messageID string, payload *gmail.MessagePart) ([]map[string]interface{}, error) {
 	var htmlBodies []string
-	collectHTMLParts(payload, &htmlBodies)
+	if err := collectHTMLParts(svc, messageID, payload, &htmlBodies); err != nil {
+		return nil, err
+	}
 
 	links := []map[string]interface{}{}
 	for _, body := range htmlBodies {
 		links = append(links, parseHTMLAnchors(body)...)
 	}
-	return links
+	return links, nil
 }
 
 // collectHTMLParts recursively collects decoded text/html body strings from a
-// MIME part tree.
-func collectHTMLParts(part *gmail.MessagePart, out *[]string) {
+// MIME part tree. When a text/html part carries Body.AttachmentId instead of
+// inline Body.Data, it fetches the body via Users.Messages.Attachments.Get
+// (requires non-nil svc and a non-empty messageID).
+func collectHTMLParts(svc *gmail.Service, messageID string, part *gmail.MessagePart, out *[]string) error {
 	if part == nil {
-		return
+		return nil
 	}
 	if part.MimeType == "text/html" {
-		if part.Body != nil && part.Body.Data != "" {
-			if data, err := base64.RawURLEncoding.DecodeString(part.Body.Data); err == nil {
-				*out = append(*out, string(data))
-			} else if data, err := base64.URLEncoding.DecodeString(part.Body.Data); err == nil {
-				*out = append(*out, string(data))
+		if part.Body != nil {
+			if part.Body.Data != "" {
+				body, err := decodeBase64URLString(part.Body.Data)
+				if err != nil {
+					return fmt.Errorf("failed to decode HTML MIME part: %w", err)
+				}
+				*out = append(*out, body)
+			} else if svc != nil && messageID != "" && part.Body.AttachmentId != "" {
+				att, err := svc.Users.Messages.Attachments.Get("me", messageID, part.Body.AttachmentId).Do()
+				if err != nil {
+					return fmt.Errorf("failed to get HTML MIME attachment %q: %w", part.Body.AttachmentId, err)
+				}
+				if att.Data != "" {
+					body, err := decodeBase64URLString(att.Data)
+					if err != nil {
+						return fmt.Errorf("failed to decode HTML MIME attachment %q: %w", part.Body.AttachmentId, err)
+					}
+					*out = append(*out, body)
+				}
 			}
 		}
-		return
+		return nil
 	}
 	for _, child := range part.Parts {
-		collectHTMLParts(child, out)
+		if err := collectHTMLParts(svc, messageID, child, out); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+// decodeBase64URLString decodes a base64url string with or without padding.
+func decodeBase64URLString(data string) (string, error) {
+	b, rawErr := base64.RawURLEncoding.DecodeString(data)
+	if rawErr == nil {
+		return string(b), nil
+	}
+	b, paddedErr := base64.URLEncoding.DecodeString(data)
+	if paddedErr == nil {
+		return string(b), nil
+	}
+	return "", fmt.Errorf("raw base64url decode failed: %w; padded base64url decode failed: %v", rawErr, paddedErr)
 }
 
 // parseHTMLAnchors extracts <a href> anchors from an HTML string and returns

--- a/cmd/gmail_test.go
+++ b/cmd/gmail_test.go
@@ -2896,3 +2896,277 @@ func TestExtractAttachments_SkipsPartsWithoutAttachmentID(t *testing.T) {
 		t.Errorf("expected no attachments, got %+v", got)
 	}
 }
+
+// TestParseGoogleDocsURL covers URL parsing for Docs links.
+func TestParseGoogleDocsURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		href     string
+		wantNil  bool
+		wantID   string
+		wantFrag string
+		wantQry  string
+		wantTab  string
+	}{
+		{
+			name:    "basic docs link",
+			href:    "https://docs.google.com/document/d/DOCID123/edit?usp=sharing",
+			wantID:  "DOCID123",
+			wantQry: "usp=sharing",
+		},
+		{
+			name:     "docs link with fragment",
+			href:     "https://docs.google.com/document/d/DOCID123/edit?usp=sharing#heading=h.abc",
+			wantID:   "DOCID123",
+			wantQry:  "usp=sharing",
+			wantFrag: "#heading=h.abc",
+		},
+		{
+			name:    "docs link with tab query param",
+			href:    "https://docs.google.com/document/d/DOCID123/edit?tab=t.0",
+			wantID:  "DOCID123",
+			wantQry: "tab=t.0",
+			wantTab: "t.0",
+		},
+		{
+			name:    "non-docs google link returns nil",
+			href:    "https://drive.google.com/file/d/XYZ/view",
+			wantNil: true,
+		},
+		{
+			name:    "non-google link returns nil",
+			href:    "https://example.com/path",
+			wantNil: true,
+		},
+		{
+			name:    "mailto returns nil",
+			href:    "mailto:user@example.com",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseGoogleDocsURL(tt.href)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if got["google_docs_id"] != tt.wantID {
+				t.Errorf("google_docs_id: want %q, got %v", tt.wantID, got["google_docs_id"])
+			}
+			if tt.wantFrag != "" {
+				if got["fragment"] != tt.wantFrag {
+					t.Errorf("fragment: want %q, got %v", tt.wantFrag, got["fragment"])
+				}
+			} else {
+				if _, ok := got["fragment"]; ok {
+					t.Errorf("expected no fragment key, got %v", got["fragment"])
+				}
+			}
+			if tt.wantQry != "" {
+				if got["query"] != tt.wantQry {
+					t.Errorf("query: want %q, got %v", tt.wantQry, got["query"])
+				}
+			}
+			if tt.wantTab != "" {
+				if got["tab_id"] != tt.wantTab {
+					t.Errorf("tab_id: want %q, got %v", tt.wantTab, got["tab_id"])
+				}
+			}
+		})
+	}
+}
+
+// TestCollectHTMLParts verifies MIME tree traversal collects text/html bodies.
+func TestCollectHTMLParts(t *testing.T) {
+	htmlBody := "<html><body>hello</body></html>"
+	htmlData := base64.URLEncoding.EncodeToString([]byte(htmlBody))
+	plainData := base64.URLEncoding.EncodeToString([]byte("hello plain"))
+
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/alternative",
+		Parts: []*gmail.MessagePart{
+			{MimeType: "text/plain", Body: &gmail.MessagePartBody{Data: plainData}},
+			{MimeType: "text/html", Body: &gmail.MessagePartBody{Data: htmlData}},
+		},
+	}
+
+	var collected []string
+	collectHTMLParts(payload, &collected)
+
+	if len(collected) != 1 {
+		t.Fatalf("expected 1 HTML body, got %d", len(collected))
+	}
+	if collected[0] != htmlBody {
+		t.Errorf("unexpected HTML body: %q", collected[0])
+	}
+}
+
+// TestCollectHTMLParts_Nested ensures nested multipart structures are traversed.
+func TestCollectHTMLParts_Nested(t *testing.T) {
+	htmlBody := "<p>nested</p>"
+	htmlData := base64.URLEncoding.EncodeToString([]byte(htmlBody))
+
+	payload := &gmail.MessagePart{
+		MimeType: "multipart/mixed",
+		Parts: []*gmail.MessagePart{
+			{
+				MimeType: "multipart/alternative",
+				Parts: []*gmail.MessagePart{
+					{MimeType: "text/plain", Body: &gmail.MessagePartBody{Data: base64.URLEncoding.EncodeToString([]byte("plain"))}},
+					{MimeType: "text/html", Body: &gmail.MessagePartBody{Data: htmlData}},
+				},
+			},
+			{MimeType: "application/pdf", Filename: "doc.pdf", Body: &gmail.MessagePartBody{AttachmentId: "att1"}},
+		},
+	}
+
+	var collected []string
+	collectHTMLParts(payload, &collected)
+
+	if len(collected) != 1 {
+		t.Fatalf("expected 1 HTML body, got %d", len(collected))
+	}
+	if collected[0] != htmlBody {
+		t.Errorf("unexpected body: %q", collected[0])
+	}
+}
+
+// TestParseHTMLAnchors verifies anchor extraction from HTML, including Gemini
+// Notes style where the visible text differs from the plain text body.
+func TestParseHTMLAnchors(t *testing.T) {
+	htmlBody := `<html><body>` +
+		`<a href="https://docs.google.com/document/d/DOCID1/edit?usp=sharing">Notes by Gemini</a>` +
+		`<a href="https://docs.google.com/document/d/DOCID1/edit?usp=sharing#heading=h.xyz">Open meeting notes</a>` +
+		`<a href="https://example.com/other">Other link</a>` +
+		`<a href="mailto:skip@example.com">Email</a>` +
+		`</body></html>`
+
+	links := parseHTMLAnchors(htmlBody)
+
+	// mailto link is excluded; 3 anchors remain
+	if len(links) != 3 {
+		t.Fatalf("expected 3 links, got %d: %+v", len(links), links)
+	}
+
+	// First link: Notes by Gemini
+	if links[0]["text"] != "Notes by Gemini" {
+		t.Errorf("link[0] text: %v", links[0]["text"])
+	}
+	if links[0]["href"] != "https://docs.google.com/document/d/DOCID1/edit?usp=sharing" {
+		t.Errorf("link[0] href: %v", links[0]["href"])
+	}
+	if links[0]["mime_part"] != "text/html" {
+		t.Errorf("link[0] mime_part: %v", links[0]["mime_part"])
+	}
+	if links[0]["google_docs_id"] != "DOCID1" {
+		t.Errorf("link[0] google_docs_id: %v", links[0]["google_docs_id"])
+	}
+
+	// Second link: has fragment
+	if links[1]["fragment"] != "#heading=h.xyz" {
+		t.Errorf("link[1] fragment: %v", links[1]["fragment"])
+	}
+
+	// Third link: non-Docs, no google_docs_id key
+	if _, ok := links[2]["google_docs_id"]; ok {
+		t.Errorf("link[2] should not have google_docs_id")
+	}
+}
+
+// TestGmailLinks_MockServer tests extractHTMLLinks against a mock Gmail API
+// response, covering the Gemini Notes email pattern.
+func TestGmailLinks_MockServer(t *testing.T) {
+	htmlBody := `<html><body>` +
+		`<a href="https://docs.google.com/document/d/GEMINI_DOC_ID/edit?usp=sharing">Notes by Gemini</a> ` +
+		`<a href="https://docs.google.com/document/d/GEMINI_DOC_ID/edit?usp=sharing&tab=t.0#heading=h.intro">Open meeting notes</a>` +
+		`</body></html>`
+	plainBody := "Notes by Gemini\nOpen meeting notes"
+
+	htmlData := base64.URLEncoding.EncodeToString([]byte(htmlBody))
+	plainData := base64.URLEncoding.EncodeToString([]byte(plainBody))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/gmail/v1/users/me/messages/gemini-msg-id" && r.Method == "GET" {
+			msg := &gmail.Message{
+				Id: "gemini-msg-id",
+				Payload: &gmail.MessagePart{
+					MimeType: "multipart/alternative",
+					Parts: []*gmail.MessagePart{
+						{MimeType: "text/plain", Body: &gmail.MessagePartBody{Data: plainData}},
+						{MimeType: "text/html", Body: &gmail.MessagePartBody{Data: htmlData}},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(msg)
+			return
+		}
+		t.Logf("Unexpected request: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	svc, err := gmail.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create gmail service: %v", err)
+	}
+
+	msg, err := svc.Users.Messages.Get("me", "gemini-msg-id").Format("full").Do()
+	if err != nil {
+		t.Fatalf("failed to get message: %v", err)
+	}
+
+	links := extractHTMLLinks(msg.Payload)
+
+	if len(links) != 2 {
+		t.Fatalf("expected 2 links, got %d: %+v", len(links), links)
+	}
+
+	// Both links point to the same doc
+	for i, link := range links {
+		if link["google_docs_id"] != "GEMINI_DOC_ID" {
+			t.Errorf("link[%d] google_docs_id: want GEMINI_DOC_ID, got %v", i, link["google_docs_id"])
+		}
+		if link["mime_part"] != "text/html" {
+			t.Errorf("link[%d] mime_part: %v", i, link["mime_part"])
+		}
+	}
+
+	if links[0]["text"] != "Notes by Gemini" {
+		t.Errorf("link[0] text: %v", links[0]["text"])
+	}
+	if links[1]["text"] != "Open meeting notes" {
+		t.Errorf("link[1] text: %v", links[1]["text"])
+	}
+
+	// Second link has fragment and tab_id
+	if links[1]["fragment"] != "#heading=h.intro" {
+		t.Errorf("link[1] fragment: %v", links[1]["fragment"])
+	}
+	if links[1]["tab_id"] != "t.0" {
+		t.Errorf("link[1] tab_id: %v", links[1]["tab_id"])
+	}
+}
+
+// TestGmailLinks_EmptyHTML ensures an empty links slice is returned for
+// messages with no HTML parts or no anchors.
+func TestGmailLinks_EmptyHTML(t *testing.T) {
+	payload := &gmail.MessagePart{
+		MimeType: "text/plain",
+		Body:     &gmail.MessagePartBody{Data: base64.URLEncoding.EncodeToString([]byte("just plain text"))},
+	}
+	links := extractHTMLLinks(payload)
+	if links == nil {
+		t.Error("expected non-nil empty slice, got nil")
+	}
+	if len(links) != 0 {
+		t.Errorf("expected 0 links, got %d", len(links))
+	}
+}

--- a/cmd/gmail_test.go
+++ b/cmd/gmail_test.go
@@ -2915,6 +2915,16 @@ func TestParseGoogleDocsURL(t *testing.T) {
 			wantQry: "usp=sharing",
 		},
 		{
+			name:   "docs host is case-insensitive",
+			href:   "https://DOCS.GOOGLE.COM/document/d/DOCID456/edit",
+			wantID: "DOCID456",
+		},
+		{
+			name:   "docs host with port",
+			href:   "https://docs.google.com:443/document/d/DOCID789/edit",
+			wantID: "DOCID789",
+		},
+		{
 			name:     "docs link with fragment",
 			href:     "https://docs.google.com/document/d/DOCID123/edit?usp=sharing#heading=h.abc",
 			wantID:   "DOCID123",

--- a/cmd/gmail_test.go
+++ b/cmd/gmail_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omriariav/workspace-cli/internal/printer"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 )
@@ -3008,7 +3009,9 @@ func TestCollectHTMLParts(t *testing.T) {
 	}
 
 	var collected []string
-	collectHTMLParts(payload, &collected)
+	if err := collectHTMLParts(nil, "", payload, &collected); err != nil {
+		t.Fatalf("collectHTMLParts: %v", err)
+	}
 
 	if len(collected) != 1 {
 		t.Fatalf("expected 1 HTML body, got %d", len(collected))
@@ -3038,7 +3041,9 @@ func TestCollectHTMLParts_Nested(t *testing.T) {
 	}
 
 	var collected []string
-	collectHTMLParts(payload, &collected)
+	if err := collectHTMLParts(nil, "", payload, &collected); err != nil {
+		t.Fatalf("collectHTMLParts: %v", err)
+	}
 
 	if len(collected) != 1 {
 		t.Fatalf("expected 1 HTML body, got %d", len(collected))
@@ -3138,7 +3143,10 @@ func TestGmailLinks_MockServer(t *testing.T) {
 		t.Fatalf("failed to get message: %v", err)
 	}
 
-	links := extractHTMLLinks(msg.Payload)
+	links, err := extractHTMLLinks(nil, "gemini-msg-id", msg.Payload)
+	if err != nil {
+		t.Fatalf("extractHTMLLinks: %v", err)
+	}
 
 	if len(links) != 2 {
 		t.Fatalf("expected 2 links, got %d: %+v", len(links), links)
@@ -3183,7 +3191,9 @@ func TestCollectHTMLParts_RawBase64(t *testing.T) {
 	}
 
 	var collected []string
-	collectHTMLParts(payload, &collected)
+	if err := collectHTMLParts(nil, "", payload, &collected); err != nil {
+		t.Fatalf("collectHTMLParts: %v", err)
+	}
 
 	if len(collected) != 1 {
 		t.Fatalf("expected 1 HTML body, got %d", len(collected))
@@ -3200,11 +3210,94 @@ func TestGmailLinks_EmptyHTML(t *testing.T) {
 		MimeType: "text/plain",
 		Body:     &gmail.MessagePartBody{Data: base64.URLEncoding.EncodeToString([]byte("just plain text"))},
 	}
-	links := extractHTMLLinks(payload)
+	links, err := extractHTMLLinks(nil, "", payload)
+	if err != nil {
+		t.Fatalf("extractHTMLLinks: %v", err)
+	}
 	if links == nil {
 		t.Error("expected non-nil empty slice, got nil")
 	}
 	if len(links) != 0 {
 		t.Errorf("expected 0 links, got %d", len(links))
+	}
+}
+
+// TestGmailLinks_RunnerLevel exercises the full runGmailLinks critical path:
+// Format("full") request, attachment-ID HTML fetch, message_id from msg.Id
+// (not CLI arg), and printer JSON output shape.
+func TestGmailLinks_RunnerLevel(t *testing.T) {
+	htmlInline := `<a href="https://docs.google.com/document/d/INLINEID/edit?usp=sharing">Inline doc</a>`
+	htmlAttach := `<a href="https://example.com/attached">Attached page</a>`
+
+	inlineData := base64.RawURLEncoding.EncodeToString([]byte(htmlInline))
+	attachData := base64.RawURLEncoding.EncodeToString([]byte(htmlAttach))
+
+	var gotFormat string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/gmail/v1/users/me/messages/cli-msg-id" && r.Method == "GET":
+			gotFormat = r.URL.Query().Get("format")
+			msg := &gmail.Message{
+				Id: "run-msg-id",
+				Payload: &gmail.MessagePart{
+					MimeType: "multipart/alternative",
+					Parts: []*gmail.MessagePart{
+						{MimeType: "text/plain", Body: &gmail.MessagePartBody{Data: base64.RawURLEncoding.EncodeToString([]byte("plain"))}},
+						// Inline HTML part
+						{MimeType: "text/html", Body: &gmail.MessagePartBody{Data: inlineData}},
+						// HTML part stored as Gmail attachment
+						{MimeType: "text/html", Body: &gmail.MessagePartBody{AttachmentId: "html-att-id"}},
+					},
+				},
+			}
+			json.NewEncoder(w).Encode(msg)
+		case r.URL.Path == "/gmail/v1/users/me/messages/run-msg-id/attachments/html-att-id" && r.Method == "GET":
+			att := &gmail.MessagePartBody{Data: attachData}
+			json.NewEncoder(w).Encode(att)
+		default:
+			t.Logf("Unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	svc, err := gmail.NewService(context.Background(), option.WithoutAuthentication(), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatalf("failed to create gmail service: %v", err)
+	}
+
+	var buf bytes.Buffer
+	p := printer.New(&buf, "json")
+	if err := runGmailLinksWithService(svc, "cli-msg-id", p); err != nil {
+		t.Fatalf("runGmailLinksWithService: %v", err)
+	}
+
+	// Verify Format("full") was used (SDK sends lowercase).
+	if strings.ToLower(gotFormat) != "full" {
+		t.Errorf("expected format=full, got %q", gotFormat)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, buf.String())
+	}
+	if parsed["message_id"] != "run-msg-id" {
+		t.Errorf("JSON message_id: want run-msg-id, got %v", parsed["message_id"])
+	}
+	parsedLinks, ok := parsed["links"].([]interface{})
+	if !ok {
+		t.Fatalf("JSON links is not an array: %T %v", parsed["links"], parsed["links"])
+	}
+	if len(parsedLinks) != 2 {
+		t.Errorf("JSON links length: want 2, got %d", len(parsedLinks))
+	}
+	first := parsedLinks[0].(map[string]interface{})
+	if first["google_docs_id"] != "INLINEID" {
+		t.Errorf("first link google_docs_id: %v", first["google_docs_id"])
+	}
+	second := parsedLinks[1].(map[string]interface{})
+	if second["href"] != "https://example.com/attached" {
+		t.Errorf("second link href: %v", second["href"])
 	}
 }

--- a/cmd/gmail_test.go
+++ b/cmd/gmail_test.go
@@ -3050,9 +3050,9 @@ func TestParseHTMLAnchors(t *testing.T) {
 
 	links := parseHTMLAnchors(htmlBody)
 
-	// mailto link is excluded; 3 anchors remain
-	if len(links) != 3 {
-		t.Fatalf("expected 3 links, got %d: %+v", len(links), links)
+	// All 4 anchors returned; mailto is included like any other href.
+	if len(links) != 4 {
+		t.Fatalf("expected 4 links, got %d: %+v", len(links), links)
 	}
 
 	// First link: Notes by Gemini
@@ -3077,6 +3077,11 @@ func TestParseHTMLAnchors(t *testing.T) {
 	// Third link: non-Docs, no google_docs_id key
 	if _, ok := links[2]["google_docs_id"]; ok {
 		t.Errorf("link[2] should not have google_docs_id")
+	}
+
+	// Fourth link: mailto included
+	if links[3]["href"] != "mailto:skip@example.com" {
+		t.Errorf("link[3] href: %v", links[3]["href"])
 	}
 }
 
@@ -3152,6 +3157,29 @@ func TestGmailLinks_MockServer(t *testing.T) {
 	}
 	if links[1]["tab_id"] != "t.0" {
 		t.Errorf("link[1] tab_id: %v", links[1]["tab_id"])
+	}
+}
+
+// TestCollectHTMLParts_RawBase64 verifies that unpadded base64url (RawURLEncoding)
+// is decoded correctly, matching Gmail's wire format which may omit padding.
+func TestCollectHTMLParts_RawBase64(t *testing.T) {
+	htmlBody := "<p>raw</p>"
+	// Encode without padding to simulate Gmail's unpadded base64url.
+	rawData := base64.RawURLEncoding.EncodeToString([]byte(htmlBody))
+
+	payload := &gmail.MessagePart{
+		MimeType: "text/html",
+		Body:     &gmail.MessagePartBody{Data: rawData},
+	}
+
+	var collected []string
+	collectHTMLParts(payload, &collected)
+
+	if len(collected) != 1 {
+		t.Fatalf("expected 1 HTML body, got %d", len(collected))
+	}
+	if collected[0] != htmlBody {
+		t.Errorf("unexpected body: %q", collected[0])
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
+	golang.org/x/net v0.49.0
 	golang.org/x/oauth2 v0.35.0
 	google.golang.org/api v0.267.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -44,7 +45,6 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
-	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect

--- a/plugins/gws/skills/gmail/SKILL.md
+++ b/plugins/gws/skills/gmail/SKILL.md
@@ -37,6 +37,7 @@ For initial setup, see the `gws-auth` skill.
 | List unread emails | `gws gmail list --query "is:unread"` |
 | Search emails | `gws gmail list --query "from:user@example.com"` |
 | Read a message | `gws gmail read <message-id>` |
+| Extract HTML links | `gws gmail links <message-id>` |
 | Read full thread | `gws gmail thread <thread-id>` |
 | Send an email | `gws gmail send --to user@example.com --subject "Hi" --body "Hello"` |
 | List all labels | `gws gmail labels` |

--- a/plugins/gws/skills/gmail/SKILL.md
+++ b/plugins/gws/skills/gmail/SKILL.md
@@ -470,6 +470,35 @@ ATT_ID=$(gws gmail read 18abc123 --format json | jq -r '.attachments[0].attachme
 gws gmail attachment --message-id 18abc123 --id "$ATT_ID" --output report.pdf
 ```
 
+### links — Extract HTML anchor links from a message
+
+```bash
+gws gmail links <message-id>
+```
+
+Fetches the full message and extracts `<a href>` anchors from `text/html` MIME parts. Useful when a message's plain text body contains visible labels like "Notes by Gemini" or "Open meeting notes" but the underlying URL is only present in the HTML part.
+
+Returns `message_id` and a `links` array in document order. Each entry has:
+- `text` — Visible anchor text
+- `href` — Full URL
+- `mime_part` — Always `"text/html"`
+- `google_docs_id` — (Google Docs only) document ID parsed from the URL path
+- `query` — (Google Docs only) raw query string, e.g. `usp=sharing`
+- `fragment` — (Google Docs only) URL fragment including `#`, e.g. `#heading=h.abc`
+- `tab_id` — (Google Docs only) tab ID from the `tab` query parameter, e.g. `t.0`
+
+`mailto:` links are excluded. Google Docs metadata fields are only present when applicable.
+
+**Examples:**
+```bash
+gws gmail links 18abc123 --format json
+
+# Gemini Notes flow: find the Google Doc URL in a Gemini Notes email.
+DOC_URL=$(gws gmail links 18abc123 --format json | jq -r '.links[] | select(.text == "Notes by Gemini") | .href')
+DOC_ID=$(gws gmail links 18abc123 --format json | jq -r '.links[] | select(.google_docs_id) | .google_docs_id' | head -1)
+gws docs read "$DOC_ID"
+```
+
 ## Tips for AI Agents
 
 - Always use `--format json` (the default) for programmatic parsing

--- a/plugins/gws/skills/gmail/SKILL.md
+++ b/plugins/gws/skills/gmail/SKILL.md
@@ -487,7 +487,7 @@ Returns `message_id` and a `links` array in document order. Each entry has:
 - `fragment` — (Google Docs only) URL fragment including `#`, e.g. `#heading=h.abc`
 - `tab_id` — (Google Docs only) tab ID from the `tab` query parameter, e.g. `t.0`
 
-`mailto:` links are excluded. Google Docs metadata fields are only present when applicable.
+All non-empty `href` anchors are returned, including `mailto:` links. Google Docs metadata fields are only present when applicable.
 
 **Examples:**
 ```bash

--- a/plugins/gws/skills/gmail/references/commands.md
+++ b/plugins/gws/skills/gmail/references/commands.md
@@ -633,4 +633,4 @@ Each link object:
 | `fragment` | string | (Google Docs only) URL fragment including `#` |
 | `tab_id` | string | (Google Docs only) `tab` query parameter value |
 
-`mailto:` links are excluded. Google Docs metadata fields are omitted when not applicable.
+All non-empty `href` anchors are returned, including `mailto:` links. Google Docs metadata fields are omitted when not applicable.

--- a/plugins/gws/skills/gmail/references/commands.md
+++ b/plugins/gws/skills/gmail/references/commands.md
@@ -605,3 +605,32 @@ Usage: gws gmail attachment [flags]
 - `status` — Always `"downloaded"`
 - `file` — Output file path
 - `size` — File size in bytes
+
+## gws gmail links
+
+Fetches the full message and extracts `<a href>` anchors from `text/html` MIME parts. Read-only; no Gmail state is modified.
+
+```
+Usage: gws gmail links <message-id>
+```
+
+No flags beyond global flags.
+
+### Output Fields (JSON)
+
+- `message_id` — Message ID
+- `links` — Array of anchor objects in document order (empty array when no anchors found)
+
+Each link object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `text` | string | Visible anchor text |
+| `href` | string | Full URL |
+| `mime_part` | string | Always `"text/html"` |
+| `google_docs_id` | string | (Google Docs only) document ID from URL path |
+| `query` | string | (Google Docs only) raw query string |
+| `fragment` | string | (Google Docs only) URL fragment including `#` |
+| `tab_id` | string | (Google Docs only) `tab` query parameter value |
+
+`mailto:` links are excluded. Google Docs metadata fields are omitted when not applicable.

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -488,7 +488,7 @@ Returns `message_id` and a `links` array in document order. Each entry has:
 - `fragment` — (Google Docs only) URL fragment including `#`, e.g. `#heading=h.abc`
 - `tab_id` — (Google Docs only) tab ID from the `tab` query parameter, e.g. `t.0`
 
-`mailto:` links are excluded. Google Docs metadata fields are only present when applicable.
+All non-empty `href` anchors are returned, including `mailto:` links. Google Docs metadata fields are only present when applicable.
 
 **Examples:**
 ```bash

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -38,6 +38,7 @@ For initial setup, see the `gws-auth` skill.
 | List unread emails | `gws gmail list --query "is:unread"` |
 | Search emails | `gws gmail list --query "from:user@example.com"` |
 | Read a message | `gws gmail read <message-id>` |
+| Extract HTML links | `gws gmail links <message-id>` |
 | Read full thread | `gws gmail thread <thread-id>` |
 | Send an email | `gws gmail send --to user@example.com --subject "Hi" --body "Hello"` |
 | List all labels | `gws gmail labels` |

--- a/skills/gmail/SKILL.md
+++ b/skills/gmail/SKILL.md
@@ -471,6 +471,35 @@ ATT_ID=$(gws gmail read 18abc123 --format json | jq -r '.attachments[0].attachme
 gws gmail attachment --message-id 18abc123 --id "$ATT_ID" --output report.pdf
 ```
 
+### links — Extract HTML anchor links from a message
+
+```bash
+gws gmail links <message-id>
+```
+
+Fetches the full message and extracts `<a href>` anchors from `text/html` MIME parts. Useful when a message's plain text body contains visible labels like "Notes by Gemini" or "Open meeting notes" but the underlying URL is only present in the HTML part.
+
+Returns `message_id` and a `links` array in document order. Each entry has:
+- `text` — Visible anchor text
+- `href` — Full URL
+- `mime_part` — Always `"text/html"`
+- `google_docs_id` — (Google Docs only) document ID parsed from the URL path
+- `query` — (Google Docs only) raw query string, e.g. `usp=sharing`
+- `fragment` — (Google Docs only) URL fragment including `#`, e.g. `#heading=h.abc`
+- `tab_id` — (Google Docs only) tab ID from the `tab` query parameter, e.g. `t.0`
+
+`mailto:` links are excluded. Google Docs metadata fields are only present when applicable.
+
+**Examples:**
+```bash
+gws gmail links 18abc123 --format json
+
+# Gemini Notes flow: find the Google Doc URL in a Gemini Notes email.
+DOC_URL=$(gws gmail links 18abc123 --format json | jq -r '.links[] | select(.text == "Notes by Gemini") | .href')
+DOC_ID=$(gws gmail links 18abc123 --format json | jq -r '.links[] | select(.google_docs_id) | .google_docs_id' | head -1)
+gws docs read "$DOC_ID"
+```
+
 ## Tips for AI Agents
 
 - Always use `--format json` (the default) for programmatic parsing

--- a/skills/gmail/references/commands.md
+++ b/skills/gmail/references/commands.md
@@ -633,4 +633,4 @@ Each link object:
 | `fragment` | string | (Google Docs only) URL fragment including `#` |
 | `tab_id` | string | (Google Docs only) `tab` query parameter value |
 
-`mailto:` links are excluded. Google Docs metadata fields are omitted when not applicable.
+All non-empty `href` anchors are returned, including `mailto:` links. Google Docs metadata fields are omitted when not applicable.

--- a/skills/gmail/references/commands.md
+++ b/skills/gmail/references/commands.md
@@ -605,3 +605,32 @@ Usage: gws gmail attachment [flags]
 - `status` — Always `"downloaded"`
 - `file` — Output file path
 - `size` — File size in bytes
+
+## gws gmail links
+
+Fetches the full message and extracts `<a href>` anchors from `text/html` MIME parts. Read-only; no Gmail state is modified.
+
+```
+Usage: gws gmail links <message-id>
+```
+
+No flags beyond global flags.
+
+### Output Fields (JSON)
+
+- `message_id` — Message ID
+- `links` — Array of anchor objects in document order (empty array when no anchors found)
+
+Each link object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `text` | string | Visible anchor text |
+| `href` | string | Full URL |
+| `mime_part` | string | Always `"text/html"` |
+| `google_docs_id` | string | (Google Docs only) document ID from URL path |
+| `query` | string | (Google Docs only) raw query string |
+| `fragment` | string | (Google Docs only) URL fragment including `#` |
+| `tab_id` | string | (Google Docs only) `tab` query parameter value |
+
+`mailto:` links are excluded. Google Docs metadata fields are omitted when not applicable.


### PR DESCRIPTION
## Summary

- Adds `gws gmail links <message-id>`: a new read-only command that fetches `Users.Messages.Get(format=full)`, recursively finds `text/html` MIME parts, and extracts `<a href>` anchors via `golang.org/x/net/html`.
- Output is `{message_id, links[]}` where each link has `text`, `href`, `mime_part`, and parsed Google Docs metadata (`google_docs_id`, `query`, `fragment`, `tab_id`) where applicable.
- Includes all anchors with `href`, including `mailto:` links; Google Docs metadata fields are omitted for non-Docs URLs.
- Handles Gmail HTML body data encoded as padded or unpadded base64url, including `text/html` parts stored behind `Body.AttachmentId` via read-only `Users.Messages.Attachments.Get`.
- Preserves all existing `gws gmail read` behavior. No Gmail mutation path is added.
- Updates README, Gmail skill docs, plugin skill mirrors, `Makefile` version, and `CLAUDE.md` current-version metadata for v1.40.1.

Refs #200

## Test plan

- [x] `go test ./cmd -run "TestGmailLinks|TestParseGoogleDocsURL|TestCollectHTMLParts|TestParseHTMLAnchors|TestGmailCommands|TestSkillCommands_MatchCLI|TestCodexSkillCommands_MatchCLI|TestCodexSkills_MirrorClaudeSkills"`
- [x] `go test ./...`
- [x] GitHub CI build check on `fad37e1c1cc16525dd18b8871bd1eab970a2c6cb`
- [x] GitHub Codex PR review action: latest comment reports no issues
- [x] Claude fullstack final review: no blocking issues, recommends merge gate
- [x] `amq-squad verify merge --evidence - --json`

## Notes

Current head is `fad37e1c1cc16525dd18b8871bd1eab970a2c6cb`. Merge state is clean, but merge and release remain gated on explicit operator approval.